### PR TITLE
Pitch display

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@
 
 .idea/
 .vscode/
+api/target/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.0.4] - 2021-05-20
+
+- Added pitch display (currently in the wrong locations relative to heatmap).
+- Added on-base and inning information.
+- Both of those required changes to `live` API response.
+
 ## [0.0.3] - 2021-05-10
 
 - Added heatmap display for current batter. The size of the heatmap needs to set dynamically still.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -467,7 +467,7 @@ dependencies = [
 
 [[package]]
 name = "mlb-api"
-version = "0.0.2"
+version = "0.0.3"
 dependencies = [
  "chrono",
  "derive_builder",
@@ -480,7 +480,7 @@ dependencies = [
 
 [[package]]
 name = "mlbt"
-version = "0.0.3"
+version = "0.0.4"
 dependencies = [
  "chrono",
  "lazy_static",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mlbt"
-version = "0.0.3"
+version = "0.0.4"
 authors = ["Andrew Schneider <andjschneider@gmail.com>"]
 edition = "2018"
 
@@ -8,7 +8,7 @@ edition = "2018"
 members = [".", "api"]
 
 [dependencies]
-mlb-api = {path = "api/", version = "0.0.2"}
+mlb-api = {path = "api/", version = "0.0.3"}
 chrono = "0.4"
 tui = "0.14"
 termion = "1.5"

--- a/api/Cargo.toml
+++ b/api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mlb-api"
-version = "0.0.2"
+version = "0.0.3"
 authors = ["Andrew Schneider <andjschneider@gmail.com>"]
 edition = "2018"
 

--- a/api/src/live.rs
+++ b/api/src/live.rs
@@ -266,6 +266,8 @@ pub struct PlayEvent {
     pub pitch_data: Option<PitchData>,
     #[serde(rename = "isPitch")]
     pub is_pitch: bool,
+    #[serde(rename = "pitchNumber")]
+    pub pitch_number: Option<u8>,
 }
 
 #[derive(Default, Debug, Serialize, Deserialize)]

--- a/api/src/live.rs
+++ b/api/src/live.rs
@@ -284,7 +284,7 @@ pub struct Details {
     pub pitch_type: Option<CodeDescription>,
 }
 
-#[derive(Default, Debug, Serialize, Deserialize)]
+#[derive(Clone, Default, Debug, Serialize, Deserialize)]
 pub struct CodeDescription {
     pub code: String,
     pub description: String,

--- a/api/src/live.rs
+++ b/api/src/live.rs
@@ -1,3 +1,4 @@
+use derive_builder::export::core::collections::HashMap;
 use serde::{Deserialize, Serialize};
 
 #[derive(Default, Debug, Serialize, Deserialize)]
@@ -207,7 +208,7 @@ pub struct Result {
     #[serde(rename = "eventType")]
     pub event_type: Option<String>,
     pub description: Option<String>,
-    pub rbi: Option<u64>,
+    pub rbi: Option<u8>,
     #[serde(rename = "awayScore")]
     pub away_score: Option<u8>,
     #[serde(rename = "homeScore")]
@@ -218,6 +219,8 @@ pub struct CurrentPlay {
     pub result: Result,
     pub count: Count,
     pub matchup: Matchup,
+    #[serde(rename = "playEvents")]
+    pub play_events: Vec<PlayEvent>,
 }
 
 #[derive(Default, Debug, Serialize, Deserialize)]
@@ -245,7 +248,6 @@ pub struct SplitStat {
 pub struct Zone {
     pub zone: String,
     pub color: String, // this is what I want: "rgba(255, 255, 255, 0.55)" -> need to convert it to a color
-    // pub temp: Temp,
     pub value: String,
 }
 
@@ -254,4 +256,61 @@ pub struct Count {
     pub balls: u8,
     pub strikes: u8,
     pub outs: u8,
+}
+
+#[derive(Default, Debug, Serialize, Deserialize)]
+pub struct PlayEvent {
+    pub details: Details,
+    pub count: Count,
+    #[serde(rename = "pitchData")]
+    pub pitch_data: Option<PitchData>,
+    #[serde(rename = "isPitch")]
+    pub is_pitch: bool,
+}
+
+#[derive(Default, Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Details {
+    pub description: String,
+    pub call: Option<CodeDescription>,
+    pub ball_color: Option<String>,
+    pub trail_color: Option<String>,
+    pub is_in_play: Option<bool>,
+    pub is_strike: Option<bool>,
+    pub is_ball: Option<bool>,
+    #[serde(rename = "type")]
+    pub pitch_type: Option<CodeDescription>,
+}
+
+#[derive(Default, Debug, Serialize, Deserialize)]
+pub struct CodeDescription {
+    pub code: String,
+    pub description: String,
+}
+
+#[derive(Default, Debug, Serialize, Deserialize)]
+pub struct PitchData {
+    #[serde(rename = "startSpeed")]
+    pub start_speed: Option<f64>,
+    #[serde(rename = "endSpeed")]
+    pub end_speed: Option<f64>,
+    #[serde(rename = "strikeZoneTop")]
+    pub strike_zone_top: Option<f64>,
+    #[serde(rename = "strikeZoneBottom")]
+    pub strike_zone_bottom: Option<f64>,
+    pub coordinates: HashMap<String, f64>,
+    pub breaks: Option<Breaks>,
+    pub zone: Option<u8>,
+    #[serde(rename = "plateTime")]
+    pub plate_time: Option<f64>,
+}
+
+#[derive(Default, Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Breaks {
+    pub break_angle: Option<f64>,
+    pub break_length: Option<f64>,
+    pub break_y: Option<f64>,
+    pub spin_rate: Option<u32>,
+    pub spin_direction: Option<u32>,
 }

--- a/api/src/live.rs
+++ b/api/src/live.rs
@@ -169,19 +169,16 @@ pub struct Person {
 }
 
 #[derive(Default, Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct Matchup {
     pub batter: Person,
-    #[serde(rename = "batSide")]
     pub bat_side: Side,
     pub pitcher: Person,
-    #[serde(rename = "pitchHand")]
     pub pitch_hand: Side,
-    // #[serde(rename = "batterHotColdZones")]
-    // pub batter_hot_cold_zones: Option<Vec<Zone>>,
-    // #[serde(rename = "pitcherHotColdZones")]
-    // pub pitcher_hot_cold_zones: Option<Vec<Option<serde_json::Value>>>,
-    #[serde(rename = "batterHotColdZoneStats")]
     pub batter_hot_cold_zone_stats: Option<BatterHotColdZoneStats>,
+    pub post_on_first: Option<Person>,
+    pub post_on_second: Option<Person>,
+    pub post_on_third: Option<Person>,
 }
 #[derive(Default, Debug, Serialize, Deserialize)]
 pub struct Side {
@@ -192,12 +189,15 @@ pub enum SideOptions {
     R,
     L,
 }
-#[derive(Debug, Serialize, Deserialize)]
-pub enum HalfInning {
-    #[serde(rename = "bottom")]
-    Bottom,
-    #[serde(rename = "top")]
-    Top,
+
+#[derive(Default, Debug, Serialize, Deserialize)]
+pub struct CurrentPlay {
+    pub result: Result,
+    pub about: About,
+    pub count: Count,
+    pub matchup: Matchup,
+    #[serde(rename = "playEvents")]
+    pub play_events: Vec<PlayEvent>,
 }
 
 #[derive(Default, Debug, Serialize, Deserialize)]
@@ -214,13 +214,16 @@ pub struct Result {
     #[serde(rename = "homeScore")]
     pub home_score: Option<u8>,
 }
+
 #[derive(Default, Debug, Serialize, Deserialize)]
-pub struct CurrentPlay {
-    pub result: Result,
-    pub count: Count,
-    pub matchup: Matchup,
-    #[serde(rename = "playEvents")]
-    pub play_events: Vec<PlayEvent>,
+#[serde(rename_all = "camelCase")]
+pub struct About {
+    pub at_bat_index: u8,
+    pub half_inning: String,
+    pub is_top_inning: bool,
+    pub inning: u8,
+    pub is_complete: bool,
+    pub is_scoring_play: Option<bool>,
 }
 
 #[derive(Default, Debug, Serialize, Deserialize)]
@@ -259,14 +262,12 @@ pub struct Count {
 }
 
 #[derive(Default, Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct PlayEvent {
     pub details: Details,
     pub count: Count,
-    #[serde(rename = "pitchData")]
     pub pitch_data: Option<PitchData>,
-    #[serde(rename = "isPitch")]
     pub is_pitch: bool,
-    #[serde(rename = "pitchNumber")]
     pub pitch_number: Option<u8>,
 }
 
@@ -291,19 +292,15 @@ pub struct CodeDescription {
 }
 
 #[derive(Default, Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct PitchData {
-    #[serde(rename = "startSpeed")]
     pub start_speed: Option<f64>,
-    #[serde(rename = "endSpeed")]
     pub end_speed: Option<f64>,
-    #[serde(rename = "strikeZoneTop")]
     pub strike_zone_top: Option<f64>,
-    #[serde(rename = "strikeZoneBottom")]
     pub strike_zone_bottom: Option<f64>,
     pub coordinates: HashMap<String, f64>,
     pub breaks: Option<Breaks>,
     pub zone: Option<u8>,
-    #[serde(rename = "plateTime")]
     pub plate_time: Option<f64>,
 }
 

--- a/api/src/live.rs
+++ b/api/src/live.rs
@@ -1,5 +1,5 @@
-use derive_builder::export::core::collections::HashMap;
 use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
 
 #[derive(Default, Debug, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]

--- a/api/src/schedule.rs
+++ b/api/src/schedule.rs
@@ -158,6 +158,8 @@ pub enum CodedGameState {
     S,
     // manager challenge
     M,
+    // unknown
+    N,
 }
 
 #[derive(Debug, strum_macros::Display, Serialize, Deserialize)]

--- a/api/src/schedule.rs
+++ b/api/src/schedule.rs
@@ -215,6 +215,9 @@ pub enum StatusCode {
     // manager challenge
     #[serde(rename = "MA")]
     Ma,
+    // manager challenge
+    #[serde(rename = "MF")]
+    Mf,
 }
 
 // #[derive(Serialize, Deserialize)]

--- a/src/app.rs
+++ b/src/app.rs
@@ -5,7 +5,7 @@ use mlb_api::MLBApi;
 #[derive(Copy, Clone, Debug, PartialEq)]
 pub enum MenuItem {
     Scoreboard,
-    GameDay,
+    Gameday,
     Stats,
     Standings,
     Help,

--- a/src/debug.rs
+++ b/src/debug.rs
@@ -5,6 +5,7 @@ use tui::Frame;
 
 pub struct DebugInfo {
     pub game_id: u64,
+    pub gameday_url: String,
     pub terminal_width: u16,
     pub terminal_height: u16,
 }
@@ -13,8 +14,8 @@ impl fmt::Display for DebugInfo {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(
             f,
-            "game id: {}\nterminal height: {} , width {}",
-            self.game_id, self.terminal_height, self.terminal_width
+            "game id: {}\ngameday: {}\nterminal height: {} width: {}",
+            self.game_id, self.gameday_url, self.terminal_height, self.terminal_width
         )
     }
 }
@@ -23,6 +24,7 @@ impl DebugInfo {
     pub fn new() -> Self {
         DebugInfo {
             game_id: 0,
+            gameday_url: "https://www.mlb.com/scores".to_string(),
             terminal_width: 0,
             terminal_height: 0,
         }
@@ -35,6 +37,7 @@ impl DebugInfo {
         B: Backend,
     {
         self.game_id = app.schedule.get_selected_game();
+        self.gameday_url = format!("https://www.mlb.com/gameday/{}", self.game_id);
         self.terminal_width = f.size().width;
         self.terminal_height = f.size().height;
     }

--- a/src/heatmap.rs
+++ b/src/heatmap.rs
@@ -1,3 +1,4 @@
+use crate::util::convert_color;
 use mlb_api::live::{LiveResponse, StatElement};
 
 use tui::style::Color;
@@ -60,7 +61,7 @@ impl Heatmap {
             for split in &z.splits {
                 if split.stat.name == "battingAverage" {
                     for zone in &split.stat.zones {
-                        let c = Heatmap::convert_color(zone.color.clone());
+                        let c = convert_color(zone.color.clone());
                         self.cells.push(c);
                         self.colors.push(c);
                         // print!("{:?} ", c);
@@ -71,45 +72,9 @@ impl Heatmap {
         }
     }
 
-    /// Convert a string from the API to a Color::Rgb. The string starts out as:
-    /// "rgba(255, 255, 255, 0.55)".
-    fn convert_color(s: String) -> Color {
-        if let Some(s) = s.strip_prefix("rgba(") {
-            let c: Vec<&str> = s.split(", ").collect();
-            Color::Rgb(
-                c[0].parse().unwrap_or(0),
-                c[1].parse().unwrap_or(0),
-                c[2].parse().unwrap_or(0),
-            )
-        } else {
-            eprintln!("color doesn't start with 'rgba(' {:?}", s);
-            Color::Rgb(0, 0, 0)
-        }
-    }
-
     fn all_black() -> Vec<Color> {
         (0..9).map(|_| Color::Rgb(0, 0, 0)).collect()
     }
-}
-
-#[test]
-fn test_color_conversion() {
-    let tests = vec![
-        ("rgba(0, 0, 0, .55)", Color::Rgb(0, 0, 0)),
-        ("rgba(6, 90, 238, .55)", Color::Rgb(6, 90, 238)),
-        ("rgba(150, 188, 255, .55)", Color::Rgb(150, 188, 255)),
-        ("rgba(214, 41, 52, .55)", Color::Rgb(214, 41, 52)),
-        ("rgba(255, 255, 255, 0.55)", Color::Rgb(255, 255, 255)),
-    ];
-    for t in tests {
-        assert_eq!(Heatmap::convert_color(t.0.to_string()), t.1);
-    }
-
-    let bad = ("rgba(55, 255, 255, 0.55)", Color::Rgb(255, 255, 255));
-    assert_ne!(Heatmap::convert_color(bad.0.to_string()), bad.1);
-
-    let nonsense = ("rgba(-5, 255, 255, 0.55)", Color::Rgb(0, 255, 255));
-    assert_eq!(Heatmap::convert_color(nonsense.0.to_string()), nonsense.1);
 }
 
 #[test]

--- a/src/heatmap.rs
+++ b/src/heatmap.rs
@@ -4,19 +4,24 @@ use tui::style::Color;
 
 pub struct Heatmap {
     pub cells: Vec<Color>,
+    pub colors: Vec<Color>,
 }
 
 impl Default for Heatmap {
     fn default() -> Self {
         Heatmap {
             cells: Heatmap::all_black(),
+            colors: Heatmap::all_black(),
         }
     }
 }
 
 impl Heatmap {
     pub fn new() -> Self {
-        Heatmap { cells: vec![] }
+        Heatmap {
+            cells: vec![],
+            colors: vec![],
+        }
     }
 
     /// Generate a heatmap from live game data. If there is no heatmap data the
@@ -57,6 +62,7 @@ impl Heatmap {
                     for zone in &split.stat.zones {
                         let c = Heatmap::convert_color(zone.color.clone());
                         self.cells.push(c);
+                        self.colors.push(c);
                         // print!("{:?} ", c);
                     }
                     // println!();

--- a/src/heatmap.rs
+++ b/src/heatmap.rs
@@ -49,7 +49,7 @@ impl Heatmap {
     /// usually 13 zones that are supplied, although I'm unsure why there are
     /// that many. I am only grabbing the first 9 to create a 3x3 heatmap. My
     /// theory is that the last 4 are used for coloring the edges of the real
-    /// heatmap shown on MLB GameDay?
+    /// heatmap shown on MLB Gameday?
     fn transform_zones(&mut self, zones: &[StatElement]) {
         for z in zones {
             // splits has 3 elements:

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,6 +6,7 @@ mod debug;
 mod event;
 mod heatmap;
 mod matchup;
+mod pitches;
 mod schedule;
 mod ui;
 
@@ -19,6 +20,7 @@ use mlb_api::MLBApiBuilder;
 
 use crate::heatmap::Heatmap;
 use crate::matchup::Matchup;
+use crate::pitches::Pitches;
 use std::error::Error;
 use std::io;
 use termion::{event::Key, raw::IntoRawMode, screen::AlternateScreen};
@@ -87,6 +89,9 @@ fn main() -> Result<(), Box<dyn Error>> {
                     let live_game = app.api.get_live_data(game_id);
                     let heatmap = Heatmap::from_live_data(&live_game);
                     heatmap.render(f, app.layout.main);
+
+                    let test = Pitches::from_live_data(&live_game);
+                    test.render(f, app.layout.main);
 
                     let matchup = Matchup::from_live_data(&live_game);
                     matchup.render(f, app.layout.main);

--- a/src/main.rs
+++ b/src/main.rs
@@ -90,11 +90,11 @@ fn main() -> Result<(), Box<dyn Error>> {
                     let heatmap = Heatmap::from_live_data(&live_game);
                     heatmap.render(f, app.layout.main);
 
-                    let test = Pitches::from_live_data(&live_game);
-                    test.render(f, app.layout.main);
-
                     let matchup = Matchup::from_live_data(&live_game);
                     matchup.render(f, app.layout.main);
+
+                    let test = Pitches::from_live_data(&live_game);
+                    test.render(f, app.layout.main);
                 }
                 MenuItem::Stats => {
                     let gameday = Paragraph::new("stats").block(tempblock.clone());

--- a/src/main.rs
+++ b/src/main.rs
@@ -50,7 +50,7 @@ fn main() -> Result<(), Box<dyn Error>> {
     let mut app = App {
         api: &mlb,
         layout: LayoutAreas::new(terminal.size().unwrap()), // TODO don't unwrap this?
-        tabs: vec!["Scoreboard", "GameDay", "Stats", "Standings"],
+        tabs: vec!["Scoreboard", "Gameday", "Stats", "Standings"],
         active_tab: MenuItem::Scoreboard,
         previous_state: MenuItem::Scoreboard,
         schedule: &mut schedule_table,
@@ -81,7 +81,7 @@ fn main() -> Result<(), Box<dyn Error>> {
                     let boxscore = BoxScore::new(&live_game.live_data.linescore);
                     boxscore.render(f, main[0]);
                 }
-                MenuItem::GameDay => {
+                MenuItem::Gameday => {
                     let gamedayp = Paragraph::new("").block(tempblock.clone());
                     f.render_widget(gamedayp, app.layout.main);
 
@@ -118,7 +118,7 @@ fn main() -> Result<(), Box<dyn Error>> {
                 Key::Char('q') => break,
 
                 Key::Char('1') => app.update_tab(MenuItem::Scoreboard),
-                Key::Char('2') => app.update_tab(MenuItem::GameDay),
+                Key::Char('2') => app.update_tab(MenuItem::Gameday),
                 Key::Char('3') => app.update_tab(MenuItem::Stats),
                 Key::Char('4') => app.update_tab(MenuItem::Standings),
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,6 +9,7 @@ mod matchup;
 mod pitches;
 mod schedule;
 mod ui;
+mod util;
 
 use crate::app::{App, DebugState, MenuItem};
 use crate::boxscore::BoxScore;

--- a/src/matchup.rs
+++ b/src/matchup.rs
@@ -4,14 +4,50 @@ use std::fmt;
 const DEFAULT_NAME: &str = "unknown";
 
 pub struct Matchup {
+    pub inning: String,
     pub pitcher_name: String,
     pub batter_name: String,
     pub count: Count,
+    pub runners: Runners,
+}
+
+#[derive(Debug, Default)]
+pub struct Runners {
+    pub first: bool,
+    pub second: bool,
+    pub third: bool,
+}
+
+impl fmt::Display for Runners {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        let mut runners = String::new();
+        if self.first {
+            runners.push_str("1st ");
+        }
+        if self.second {
+            runners.push_str("2nd ");
+        }
+        if self.third {
+            runners.push_str("3rd");
+        }
+        write!(f, "{}", runners)
+    }
+}
+
+impl Runners {
+    pub fn from_matchup(matchup: &mlb_api::live::Matchup) -> Self {
+        Runners {
+            first: matchup.post_on_first.is_some(),
+            second: matchup.post_on_second.is_some(),
+            third: matchup.post_on_third.is_some(),
+        }
+    }
 }
 
 impl Default for Matchup {
     fn default() -> Self {
         Matchup {
+            inning: DEFAULT_NAME.to_string(),
             pitcher_name: DEFAULT_NAME.to_string(),
             batter_name: DEFAULT_NAME.to_string(),
             count: Count {
@@ -19,6 +55,7 @@ impl Default for Matchup {
                 balls: 0,
                 outs: 0,
             },
+            runners: Runners::default(),
         }
     }
 }
@@ -27,12 +64,14 @@ impl fmt::Display for Matchup {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(
             f,
-            "pitcher: {}\nbatter: {}\n{}-{} {} out",
+            " inning: {}\n pitching: {}\n at bat:   {}\n balls: {:>3}\n strikes: {}\n outs: {:>4}\n on base: {}",
+            self.inning,
             self.pitcher_name,
             self.batter_name,
             self.count.balls,
             self.count.strikes,
             self.count.outs,
+            self.runners,
         )
     }
 }
@@ -48,16 +87,19 @@ impl Matchup {
 
         // TODO probably don't need to clone all of these
         Matchup {
+            inning: format!("{} {}", current.about.half_inning, current.about.inning),
             pitcher_name: current.matchup.pitcher.full_name.clone(),
             batter_name: current.matchup.batter.full_name.clone(),
             count: current.count.clone(),
+            runners: Runners::from_matchup(&current.matchup),
         }
     }
 }
 
 #[test]
-fn test_string_display() {
+fn test_matchup_string_display() {
     let matchup = Matchup {
+        inning: "bottom 9".to_string(),
         pitcher_name: "Nolan Ryan".to_string(),
         batter_name: "Sammy Sosa".to_string(),
         count: Count {
@@ -65,14 +107,54 @@ fn test_string_display() {
             strikes: 2,
             outs: 2,
         },
+        runners: Runners {
+            first: true,
+            second: true,
+            third: true,
+        },
     };
-    let w = format!(
-        "pitcher: {}\nbatter: {}\n{}-{} {} out",
-        matchup.pitcher_name,
-        matchup.batter_name,
-        matchup.count.balls,
-        matchup.count.strikes,
-        matchup.count.outs,
-    );
+    let w = r" inning: bottom 9
+ pitching: Nolan Ryan
+ at bat:   Sammy Sosa
+ balls:   3
+ strikes: 2
+ outs:    2
+ on base: 1st 2nd 3rd"
+        .to_string();
     assert_eq!(w, matchup.to_string());
+}
+
+#[test]
+fn test_matchup_default_runners() {
+    // verify that the default is to have no runners on base
+    let r = Runners::default();
+    assert!(!r.first);
+    assert!(!r.second);
+    assert!(!r.third);
+}
+
+#[test]
+#[rustfmt::skip] 
+fn test_matchup_runners_display() {
+    // test that the runners are displayed correctly
+    let on_first = Runners{first: true, second: false, third: false};
+    assert_eq!("1st ".to_string(), on_first.to_string());
+
+    let on_second = Runners{first: false, second: true, third: false};
+    assert_eq!("2nd ".to_string(), on_second.to_string());
+
+    let on_third = Runners{first: false, second: false, third: true};
+    assert_eq!("3rd".to_string(), on_third.to_string());
+
+    let first_second = Runners{first: true, second: true, third: false};
+    assert_eq!("1st 2nd ".to_string(), first_second.to_string());
+
+    let first_third = Runners{first: true, second: false, third: true};
+    assert_eq!("1st 3rd".to_string(), first_third.to_string());
+
+    let second_third = Runners{first: false, second: true, third: true};
+    assert_eq!("2nd 3rd".to_string(), second_third.to_string());
+
+    let loaded = Runners{first: true, second: true, third: true};
+    assert_eq!("1st 2nd 3rd".to_string(), loaded.to_string());
 }

--- a/src/pitches.rs
+++ b/src/pitches.rs
@@ -5,9 +5,10 @@ use tui::style::Color;
 pub struct Pitch {
     pub strike: bool,
     pub color: Color,
-    pub description: String, // fastball, slider, ect.
+    pub description: String, // called strike, hit, strike out, ect.
     pub location: (f64, f64),
     pub index: u8,
+    pub pitch_type: String, // fastball, slider, ect.
 }
 
 #[derive(Default)]
@@ -34,6 +35,7 @@ impl Pitches {
         for play in plays {
             if play.is_pitch {
                 let pitch_data = play.pitch_data.as_ref().unwrap(); // TODO
+                let pitch_details = &play.details;
 
                 let info = &pitch_data.coordinates;
                 let x_coord = info.get("pX").unwrap();
@@ -42,11 +44,17 @@ impl Pitches {
                 // z coordinate is up/down
                 // y coordinate is catcher looking towards pitcher
                 let pitch = Pitch {
-                    strike: play.details.is_strike.unwrap(),
+                    strike: pitch_details.is_strike.unwrap(),
                     color: Pitches::convert_color(
-                        play.details.ball_color.clone().unwrap_or_default(),
+                        pitch_details.ball_color.clone().unwrap_or_default(),
                     ),
-                    description: play.details.description.to_string(),
+                    description: pitch_details.description.to_string(),
+                    pitch_type: pitch_details
+                        .pitch_type
+                        .clone()
+                        .unwrap_or_default()
+                        .description
+                        .clone(),
                     location: (*x_coord, *z_coord),
                     index: play.pitch_number.unwrap_or_default(),
                 };

--- a/src/pitches.rs
+++ b/src/pitches.rs
@@ -36,9 +36,8 @@ impl Pitches {
                 let pitch_data = play.pitch_data.as_ref().unwrap(); // TODO
 
                 let info = &pitch_data.coordinates;
-                // TODO scale?
-                let x_coord = info.get("pX").unwrap() * 10.0;
-                let z_coord = info.get("pZ").unwrap() * 10.0;
+                let x_coord = info.get("pX").unwrap();
+                let z_coord = info.get("pZ").unwrap();
                 // x coordinate is left/right
                 // z coordinate is up/down
                 // y coordinate is catcher looking towards pitcher
@@ -48,7 +47,7 @@ impl Pitches {
                         play.details.ball_color.clone().unwrap_or_default(),
                     ),
                     description: play.details.description.to_string(),
-                    location: (x_coord, z_coord),
+                    location: (*x_coord, *z_coord),
                     index: play.pitch_number.unwrap_or_default(),
                 };
                 self.pitches.push(pitch);

--- a/src/pitches.rs
+++ b/src/pitches.rs
@@ -7,6 +7,7 @@ pub struct Pitch {
     pub color: Color,
     pub description: String, // fastball, slider, ect.
     pub location: (f64, f64),
+    pub index: u8,
 }
 
 #[derive(Default)]
@@ -35,8 +36,9 @@ impl Pitches {
                 let pitch_data = play.pitch_data.as_ref().unwrap(); // TODO
 
                 let info = &pitch_data.coordinates;
-                let x_coord = info.get("pX").unwrap();
-                let z_coord = info.get("pZ").unwrap();
+                // TODO scale?
+                let x_coord = info.get("pX").unwrap() * 10.0;
+                let z_coord = info.get("pZ").unwrap() * 10.0;
                 // x coordinate is left/right
                 // z coordinate is up/down
                 // y coordinate is catcher looking towards pitcher
@@ -46,7 +48,8 @@ impl Pitches {
                         play.details.ball_color.clone().unwrap_or_default(),
                     ),
                     description: play.details.description.to_string(),
-                    location: (*x_coord, *z_coord),
+                    location: (x_coord, z_coord),
+                    index: play.pitch_number.unwrap_or_default(),
                 };
                 self.pitches.push(pitch);
                 // println!("{:?}", pitch_data)

--- a/src/pitches.rs
+++ b/src/pitches.rs
@@ -24,10 +24,10 @@ impl Default for Pitches {
             pitches: vec![Pitch {
                 strike: false,
                 color: Color::Black,
-                description: "error".to_string(),
+                description: "no pitch".to_string(),
                 location: (0.0, 0.0),
                 index: 0,
-                pitch_type: "error".to_string(),
+                pitch_type: "no pitch".to_string(),
             }],
         }
     }

--- a/src/pitches.rs
+++ b/src/pitches.rs
@@ -1,0 +1,72 @@
+use mlb_api::live::{LiveResponse, PlayEvent};
+
+use tui::style::Color;
+
+pub struct Pitch {
+    pub strike: bool,
+    pub color: Color,
+    pub description: String, // fastball, slider, ect.
+    pub location: (f64, f64),
+}
+
+#[derive(Default)]
+pub struct Pitches {
+    pub pitches: Vec<Pitch>,
+}
+
+impl Pitches {
+    pub fn new() -> Self {
+        Pitches { pitches: vec![] }
+    }
+
+    pub fn from_live_data(live_game: &LiveResponse) -> Pitches {
+        let pitch_data = match live_game.live_data.plays.current_play.as_ref() {
+            Some(c) => &c.play_events,
+            None => return Pitches::default(),
+        };
+        let mut pitches = Pitches::new();
+        pitches.transform_pitches(pitch_data);
+        pitches
+    }
+
+    fn transform_pitches(&mut self, plays: &[PlayEvent]) {
+        for play in plays {
+            if play.is_pitch {
+                let pitch_data = play.pitch_data.as_ref().unwrap(); // TODO
+
+                let info = &pitch_data.coordinates;
+                let x_coord = info.get("pX").unwrap();
+                let z_coord = info.get("pZ").unwrap();
+                // x coordinate is left/right
+                // z coordinate is up/down
+                // y coordinate is catcher looking towards pitcher
+                let pitch = Pitch {
+                    strike: play.details.is_strike.unwrap(),
+                    color: Pitches::convert_color(
+                        play.details.ball_color.clone().unwrap_or_default(),
+                    ),
+                    description: play.details.description.to_string(),
+                    location: (*x_coord, *z_coord),
+                };
+                self.pitches.push(pitch);
+                // println!("{:?}", pitch_data)
+            }
+        }
+    }
+
+    /// Convert a string from the API to a Color::Rgb. The string starts out as:
+    /// "rgba(255, 255, 255, 0.55)".
+    fn convert_color(s: String) -> Color {
+        if let Some(s) = s.strip_prefix("rgba(") {
+            let c: Vec<&str> = s.split(", ").collect();
+            Color::Rgb(
+                c[0].parse().unwrap_or(0),
+                c[1].parse().unwrap_or(0),
+                c[2].parse().unwrap_or(0),
+            )
+        } else {
+            eprintln!("color doesn't start with 'rgba(' {:?}", s);
+            Color::Rgb(0, 0, 0)
+        }
+    }
+}

--- a/src/ui/boxscore.rs
+++ b/src/ui/boxscore.rs
@@ -8,19 +8,14 @@ use tui::{
 
 use crate::boxscore::BoxScore;
 
-// The longest game in MLB history was 26 innings. There are four extra columns:
-// team name, runs, hits, and errors, so having a max width of 30 for the boxscore
-// seems pretty safe.
-const BOXSCORE_WIDTHS: &[Constraint] = &[Constraint::Length(4); 30];
-
 impl BoxScore {
     pub fn render<B>(&self, f: &mut Frame<B>, rect: Rect)
     where
         B: Backend,
     {
-        // slice off the correct number of widths TODO is there a better way to do this?
-        let widths: &[Constraint] = &BOXSCORE_WIDTHS[0..self.header.len()];
-        // let widths: &[Constraint] = vec![Constraint::Length(4); header_row.len()].as_slice();
+        let mut widths = vec![Constraint::Length(4); self.header.len()];
+        // the first width needs to be wider to display the team name
+        widths[0] = Constraint::Length(10);
 
         let header = Row::new(self.header.clone())
             .height(1)
@@ -35,7 +30,7 @@ impl BoxScore {
             Row::new(self.away.create_score_vec()).bottom_margin(1),
             Row::new(self.home.create_score_vec()),
         ])
-        .widths(widths)
+        .widths(widths.as_slice())
         .column_spacing(1)
         .style(Style::default().fg(Color::White))
         .header(header)

--- a/src/ui/heatmap.rs
+++ b/src/ui/heatmap.rs
@@ -1,12 +1,15 @@
 use super::super::heatmap::Heatmap;
-use super::utils::centered_rect;
+
 use tui::{
     backend::Backend,
-    layout::{Constraint, Rect},
-    style::Style,
-    widgets::{Block, Borders, Cell, Row, Table},
+    layout::Rect,
+    widgets::canvas::{Canvas, Rectangle},
+    widgets::{Block, Borders},
     Frame,
 };
+
+#[derive(Debug, PartialEq)]
+struct Coordinate(f64, f64);
 
 impl Heatmap {
     pub fn render<B>(&self, f: &mut Frame<B>, rect: Rect)
@@ -14,41 +17,68 @@ impl Heatmap {
         B: Backend,
     {
         // these should be determined by the terminal size
-        let width = 5;
-        let height = 3;
+        let width = 30; // x
+        let height = 45; // y
 
-        // TODO probably a better way to do this
-        let top = Row::new(vec![
-            Cell::from("").style(Style::default().bg(self.cells[0])),
-            Cell::from("").style(Style::default().bg(self.cells[1])),
-            Cell::from("").style(Style::default().bg(self.cells[2])),
-        ])
-        .height(height);
-        let middle = Row::new(vec![
-            Cell::from("").style(Style::default().bg(self.cells[3])),
-            Cell::from("").style(Style::default().bg(self.cells[4])),
-            Cell::from("").style(Style::default().bg(self.cells[5])),
-        ])
-        .height(height);
-        let bottom = Row::new(vec![
-            Cell::from("").style(Style::default().bg(self.cells[6])),
-            Cell::from("").style(Style::default().bg(self.cells[7])),
-            Cell::from("").style(Style::default().bg(self.cells[8])),
-        ])
-        .height(height);
+        let coords = build_coords(width, height);
 
-        let widths = [
-            Constraint::Length(width),
-            Constraint::Length(width),
-            Constraint::Length(width),
-        ];
-        let t = Table::new(vec![top, middle, bottom])
-            .block(Block::default().borders(Borders::NONE).title("heatmap"))
-            .widths(&widths)
-            .column_spacing(0);
+        let canvas = Canvas::default()
+            .block(Block::default().borders(Borders::ALL))
+            .paint(|ctx| {
+                for (i, coord) in coords.iter().enumerate() {
+                    let r = Rectangle {
+                        x: coord.0,
+                        y: coord.1,
+                        width: (width / 3) as f64,
+                        height: (height / 3) as f64,
+                        color: self.colors[i],
+                    };
+                    ctx.draw(&r);
+                }
+            })
+            // TODO figure out bounds
+            .x_bounds([-100.0, 100.0])
+            .y_bounds([-100.0, 100.0]);
 
-        // TODO the size of the centered rect needs to be dynamic
-        let area = centered_rect(15, 15, rect);
-        f.render_widget(t, area);
+        f.render_widget(canvas, rect);
     }
+}
+
+/// Builds the coordinates for the 3x3 heatmap. Each coordinate represents the upper left corner of
+/// a heatmap zone. A tui-rs rectangle is then built from a coordinate; its positive X axis going
+/// right, and positive Y axis going down, from the coordinate.
+fn build_coords(width: u16, height: u16) -> Vec<Coordinate> {
+    let width_chunk = width / 3;
+    let height_chunk = height / 3;
+
+    let x_coords: Vec<_> = (0..width).step_by(width_chunk as usize).collect();
+    let y_coords: Vec<_> = (0..height).step_by(height_chunk as usize).collect();
+
+    let mut coords = Vec::new();
+    for x in &x_coords {
+        for y in &y_coords {
+            coords.push(Coordinate(*x as f64, *y as f64));
+        }
+    }
+    coords
+}
+
+#[test]
+fn test_coords() {
+    let width = 6;
+    let height = 3;
+    let coords = build_coords(width, height);
+    println!("{:?}", coords);
+    let w = vec![
+        Coordinate(0.0, 0.0),
+        Coordinate(0.0, 1.0),
+        Coordinate(0.0, 2.0),
+        Coordinate(2.0, 0.0),
+        Coordinate(2.0, 1.0),
+        Coordinate(2.0, 2.0),
+        Coordinate(4.0, 0.0),
+        Coordinate(4.0, 1.0),
+        Coordinate(4.0, 2.0),
+    ];
+    assert_eq!(w, coords);
 }

--- a/src/ui/help.rs
+++ b/src/ui/help.rs
@@ -16,7 +16,7 @@ pub fn get_help_docs() -> Vec<Vec<String>> {
     vec![
         vec!["Quit".to_string(), "q".to_string()],
         vec!["Scoreboard".to_string(), "1".to_string()],
-        vec!["GameDay".to_string(), "2".to_string()],
+        vec!["Gameday".to_string(), "2".to_string()],
         vec!["Stats".to_string(), "3".to_string()],
         vec!["Standings".to_string(), "4".to_string()],
         vec!["".to_string(), "".to_string()],

--- a/src/ui/layout.rs
+++ b/src/ui/layout.rs
@@ -12,6 +12,7 @@ impl LayoutAreas {
     pub fn new(size: Rect) -> Self {
         let chunks = Layout::default()
             .direction(Direction::Vertical)
+            .margin(1)
             .constraints(
                 [
                     Constraint::Length(TOP_BAR_HEIGHT),

--- a/src/ui/layout.rs
+++ b/src/ui/layout.rs
@@ -50,4 +50,13 @@ impl LayoutAreas {
             .constraints([Constraint::Percentage(90), Constraint::Percentage(10)].as_ref())
             .split(area)
     }
+
+    /// Create a split in the `main` section so that the top Rect is sized correctly to display a
+    /// box score.
+    pub fn for_boxscore(&self) -> Vec<Rect> {
+        Layout::default()
+            .direction(Direction::Vertical)
+            .constraints([Constraint::Length(7), Constraint::Percentage(100)].as_ref())
+            .split(self.main)
+    }
 }

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -4,6 +4,7 @@ pub(crate) mod heatmap;
 pub(crate) mod help;
 pub(crate) mod layout;
 pub(crate) mod matchup;
+pub(crate) mod pitches;
 pub(crate) mod schedule;
 pub(crate) mod tabs;
 mod utils;

--- a/src/ui/pitches.rs
+++ b/src/ui/pitches.rs
@@ -1,0 +1,36 @@
+use super::super::pitches::Pitches;
+use super::utils::centered_rect;
+use std::borrow::Borrow;
+use tui::style::Color;
+use tui::widgets::canvas::{Canvas, Points};
+use tui::{
+    backend::Backend,
+    layout::Rect,
+    style::Style,
+    widgets::{Block, Borders},
+    Frame,
+};
+
+impl Pitches {
+    pub fn render<B>(&self, f: &mut Frame<B>, rect: Rect)
+    where
+        B: Backend,
+    {
+        let canvas = Canvas::default()
+            .block(Block::default().borders(Borders::ALL))
+            .paint(|ctx| {
+                for pitch in &self.pitches {
+                    let ball = Points {
+                        coords: &[pitch.location],
+                        color: pitch.color,
+                    };
+                    ctx.draw(&ball);
+                }
+            })
+            .x_bounds([-100.0, 100.0])
+            .y_bounds([-100.0, 100.0]);
+
+        // TODO figure out bounds, location of canvas, ect.
+        f.render_widget(canvas, rect);
+    }
+}

--- a/src/ui/pitches.rs
+++ b/src/ui/pitches.rs
@@ -1,70 +1,97 @@
 use super::super::pitches::Pitches;
-use tui::style::Color;
-use tui::widgets::canvas::{Canvas, Painter, Points, Shape};
+use tui::layout::{Constraint, Direction, Layout};
+use tui::text::{Span, Spans};
+use tui::widgets::{List, ListItem};
 use tui::{
     backend::Backend,
     layout::Rect,
+    widgets::canvas::{Canvas, Rectangle},
     widgets::{Block, Borders},
     Frame,
 };
+use tui::{layout::Corner, style::Style};
 
-/// Shape to draw a rectangle from a `Rect` with the given color
-#[derive(Debug, Clone)]
-pub struct Circle {
-    pub x: f64,
-    pub y: f64,
-    pub radius: f64,
-    pub color: Color,
-}
-
-impl Shape for Circle {
-    fn draw(&self, painter: &mut Painter) {
-        // TODO this doesn't look great, might want to look into drawing the circle based on the grid of the terminal
-        let mut coords: Vec<(f64, f64)> = Vec::new();
-        let num_points = 9;
-        let chunks = 2.0 * core::f64::consts::PI / num_points as f64;
-        for i in 0..num_points {
-            let theta = chunks * i as f64;
-            let x = (self.radius * f64::cos(theta)) + self.x;
-            let y = (self.radius * f64::sin(theta)) + self.y;
-            coords.push((x, y));
-        }
-        // TODO fill in the circle too?
-        for coord in coords {
-            let pt = Points {
-                coords: &[coord],
-                color: self.color,
-            };
-            pt.draw(painter)
-        }
-    }
-}
+// TODO figure out better way to do this? used for the pitch label
+static TEST: &[&str] = &[
+    "0", "1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "15",
+];
 
 impl Pitches {
     pub fn render<B>(&self, f: &mut Frame<B>, rect: Rect)
     where
         B: Backend,
     {
+        let chunks = Layout::default()
+            .direction(Direction::Horizontal)
+            .constraints(
+                [
+                    Constraint::Percentage(30), // left
+                    Constraint::Percentage(40), // heatmap
+                    Constraint::Percentage(30), // right
+                ]
+                .as_ref(),
+            )
+            .split(rect);
+        let left = Layout::default()
+            .direction(Direction::Vertical)
+            .constraints(
+                [
+                    Constraint::Length(20),      // matchup
+                    Constraint::Percentage(100), // pitch info
+                ]
+                .as_ref(),
+            )
+            .split(chunks[0]);
+
+        // TODO scale this correctly so it overlays the heatmap
+        let scale = 13f64;
+        let ball_scale = 3.0;
         let canvas = Canvas::default()
-            .block(Block::default().borders(Borders::ALL))
+            .block(Block::default().borders(Borders::TOP | Borders::BOTTOM))
             .paint(|ctx| {
                 for pitch in &self.pitches {
-                    let circle = Circle {
-                        x: pitch.location.0,
-                        y: pitch.location.1,
-                        radius: 1.0,
+                    let ball = Rectangle {
                         color: pitch.color,
+                        height: scale / ball_scale,
+                        width: scale / ball_scale,
+                        x: pitch.location.0 * scale,
+                        y: pitch.location.1 * scale,
                     };
-                    ctx.draw(&circle);
-                    // TODO fix this
-                    // let text = pitch.index.to_string().as_str();
-                    // ctx.print(circle.x + 1.0, circle.y, text, Color::White)
+                    ctx.draw(&ball);
+                    ctx.print(
+                        ball.x,
+                        // ball.x + (ball.height / 2.0),
+                        ball.y,
+                        // ball.y + (ball.width / 2.0),
+                        TEST[pitch.index as usize],
+                        pitch.color,
+                    )
                 }
             })
             .x_bounds([-100.0, 100.0])
             .y_bounds([-100.0, 100.0]);
 
         // TODO figure out bounds, location of canvas, ect.
-        f.render_widget(canvas, rect);
+        f.render_widget(canvas, chunks[1]);
+
+        // display the pitch information
+        let pitches: Vec<ListItem> = self
+            .pitches
+            .iter()
+            .map(|pitch| {
+                ListItem::new(vec![Spans::from(vec![
+                    Span::styled(
+                        format!("  {} ", TEST[pitch.index as usize]),
+                        Style::default().fg(pitch.color), // TODO color doesn't seem to work
+                    ),
+                    Span::raw(format!(" {} | {} ", &pitch.description, &pitch.pitch_type)),
+                ])])
+            })
+            .collect();
+
+        let events_list = List::new(pitches)
+            .block(Block::default().borders(Borders::LEFT))
+            .start_corner(Corner::TopLeft);
+        f.render_widget(events_list, left[1]);
     }
 }

--- a/src/ui/pitches.rs
+++ b/src/ui/pitches.rs
@@ -1,15 +1,44 @@
 use super::super::pitches::Pitches;
-use super::utils::centered_rect;
-use std::borrow::Borrow;
 use tui::style::Color;
-use tui::widgets::canvas::{Canvas, Points};
+use tui::widgets::canvas::{Canvas, Painter, Points, Shape};
 use tui::{
     backend::Backend,
     layout::Rect,
-    style::Style,
     widgets::{Block, Borders},
     Frame,
 };
+
+/// Shape to draw a rectangle from a `Rect` with the given color
+#[derive(Debug, Clone)]
+pub struct Circle {
+    pub x: f64,
+    pub y: f64,
+    pub radius: f64,
+    pub color: Color,
+}
+
+impl Shape for Circle {
+    fn draw(&self, painter: &mut Painter) {
+        // TODO this doesn't look great, might want to look into drawing the circle based on the grid of the terminal
+        let mut coords: Vec<(f64, f64)> = Vec::new();
+        let num_points = 9;
+        let chunks = 2.0 * core::f64::consts::PI / num_points as f64;
+        for i in 0..num_points {
+            let theta = chunks * i as f64;
+            let x = (self.radius * f64::cos(theta)) + self.x;
+            let y = (self.radius * f64::sin(theta)) + self.y;
+            coords.push((x, y));
+        }
+        // TODO fill in the circle too?
+        for coord in coords {
+            let pt = Points {
+                coords: &[coord],
+                color: self.color,
+            };
+            pt.draw(painter)
+        }
+    }
+}
 
 impl Pitches {
     pub fn render<B>(&self, f: &mut Frame<B>, rect: Rect)
@@ -20,11 +49,16 @@ impl Pitches {
             .block(Block::default().borders(Borders::ALL))
             .paint(|ctx| {
                 for pitch in &self.pitches {
-                    let ball = Points {
-                        coords: &[pitch.location],
+                    let circle = Circle {
+                        x: pitch.location.0,
+                        y: pitch.location.1,
+                        radius: 1.0,
                         color: pitch.color,
                     };
-                    ctx.draw(&ball);
+                    ctx.draw(&circle);
+                    // TODO fix this
+                    // let text = pitch.index.to_string().as_str();
+                    // ctx.print(circle.x + 1.0, circle.y, text, Color::White)
                 }
             })
             .x_bounds([-100.0, 100.0])

--- a/src/ui/pitches.rs
+++ b/src/ui/pitches.rs
@@ -2,13 +2,13 @@ use super::super::pitches::Pitches;
 use crate::pitches::Pitch;
 use tui::{
     backend::Backend,
-    layout::{Constraint, Direction, Layout, Rect},
+    layout::{Constraint, Corner, Direction, Layout, Rect},
+    style::Style,
     text::{Span, Spans},
     widgets::canvas::{Canvas, Rectangle},
     widgets::{Block, Borders, List, ListItem},
     Frame,
 };
-use tui::{layout::Corner, style::Style};
 
 // TODO figure out better way to do this? used for the pitch label
 static TEST: &[&str] = &[

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,0 +1,37 @@
+use tui::style::Color;
+
+/// Convert a string from the API to a Color::Rgb. The string starts out as:
+/// "rgba(255, 255, 255, 0.55)".
+pub(crate) fn convert_color(s: String) -> Color {
+    if let Some(s) = s.strip_prefix("rgba(") {
+        let c: Vec<&str> = s.split(", ").collect();
+        Color::Rgb(
+            c[0].parse().unwrap_or(0),
+            c[1].parse().unwrap_or(0),
+            c[2].parse().unwrap_or(0),
+        )
+    } else {
+        eprintln!("color doesn't start with 'rgba(' {:?}", s);
+        Color::Rgb(0, 0, 0)
+    }
+}
+
+#[test]
+fn test_color_conversion() {
+    let tests = vec![
+        ("rgba(0, 0, 0, .55)", Color::Rgb(0, 0, 0)),
+        ("rgba(6, 90, 238, .55)", Color::Rgb(6, 90, 238)),
+        ("rgba(150, 188, 255, .55)", Color::Rgb(150, 188, 255)),
+        ("rgba(214, 41, 52, .55)", Color::Rgb(214, 41, 52)),
+        ("rgba(255, 255, 255, 0.55)", Color::Rgb(255, 255, 255)),
+    ];
+    for t in tests {
+        assert_eq!(convert_color(t.0.to_string()), t.1);
+    }
+
+    let bad = ("rgba(55, 255, 255, 0.55)", Color::Rgb(255, 255, 255));
+    assert_ne!(convert_color(bad.0.to_string()), bad.1);
+
+    let nonsense = ("rgba(-5, 255, 255, 0.55)", Color::Rgb(0, 255, 255));
+    assert_eq!(convert_color(nonsense.0.to_string()), nonsense.1);
+}


### PR DESCRIPTION
Added the initial pitch display to the Gameday tab. Seems to be working well, except the locations. When I refactor all of the layout code I will revisit this.

- changed the heat map to display [Rectangles](https://docs.rs/tui/0.15.0/tui/widgets/canvas/struct.Rectangle.html) on a Canvas, instead of using a Table. I think it looks better (less bright) but I still might fill them in. This closes issue #3 since it's not relevant anymore - the canvas automatically resizes.

- fixed issue #5 