### PR TITLE
Date selection for schedule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Standings view: [PR 19](https://github.com/mlb-rs/mlbt/pull/19)
 - Added integration tests for the API
 - Updated `Help` display to alert user if terminal is too small: [PR 20](https://github.com/mlb-rs/mlbt/pull/20)
+- Added a date picker to view schedule on a different day: [PR 21](https://github.com/mlb-rs/mlbt/pull/21)
 
 ## [0.0.7] - 2021-06-05
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -626,7 +626,7 @@ dependencies = [
 
 [[package]]
 name = "mlbt"
-version = "0.0.7-alpha2"
+version = "0.0.7-alpha3"
 dependencies = [
  "chrono",
  "chrono-tz",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mlbt"
-version = "0.0.7-alpha2"
+version = "0.0.7-alpha3"
 authors = ["Andrew Schneider <andjschneider@gmail.com>"]
 edition = "2018"
 

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ TODO - add to crates.io
 ## Features
 
 - [X] scoreboard and box score
-  - [ ] selectable date
+  - [X] selectable date
 
 - [X] gameday
 
@@ -104,6 +104,10 @@ Press `1` to activate this tab.
 
 - `j`: move down
 - `k`: move up
+- `:`: activate date picker
+
+With the date picker active, input a date in the form of `YYYY-MM-DD` and press
+`Enter`. This will display the schedule for that day.
 
 ### Gameday
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -10,6 +10,7 @@ pub enum MenuItem {
     Stats,
     Standings,
     Help,
+    DatePicker,
 }
 
 pub struct App {

--- a/src/app.rs
+++ b/src/app.rs
@@ -18,6 +18,7 @@ pub struct App {
     pub previous_state: MenuItem,
     pub debug_state: DebugState,
     pub schedule: ScheduleState,
+    pub date_input: String,
     pub live_game: GameState,
     pub gameday: GamedayPanels,
     pub boxscore_tab: BoxscoreTab,

--- a/src/draw.rs
+++ b/src/draw.rs
@@ -109,7 +109,7 @@ where
     let directions = Paragraph::new(" Press Enter to submit or Esc to cancel");
     f.render_widget(directions, lines[1]);
 
-    let input = Paragraph::new(" > ");
+    let input = Paragraph::new(format!(" {}", app.date_input));
     f.render_widget(input, lines[2]);
 
     let block = Block::default()
@@ -118,6 +118,9 @@ where
         .border_type(BorderType::Rounded)
         .border_style(Style::default().fg(Color::Blue));
     f.render_widget(block, chunk);
+
+    // display cursor
+    f.set_cursor(lines[2].x + app.date_input.len() as u16 + 1, lines[2].y)
 }
 
 fn draw_gameday<B>(f: &mut Frame<B>, rect: Rect, app: &mut App)

--- a/src/draw.rs
+++ b/src/draw.rs
@@ -53,6 +53,10 @@ where
                         &mut app.live_game.linescore,
                     );
                 }
+                MenuItem::DatePicker => {
+                    // let chunks =
+                    // draw_date_picker(f, main_layout.main, app);
+                }
                 MenuItem::Gameday => {
                     draw_gameday(f, main_layout.main, app);
                 }
@@ -93,7 +97,7 @@ fn draw_gameday<B>(f: &mut Frame<B>, rect: Rect, app: &mut App)
 where
     B: Backend,
 {
-    let mut panels = LayoutAreas::generate_layouts(&app.gameday, rect);
+    let mut panels = LayoutAreas::generate_gameday_panels(&app.gameday, rect);
 
     // I want the panels to be displayed [Info, Heat, Box] from left to right. So pop off
     // available panels starting with Box. Since `generate_layouts` takes into account how many

--- a/src/event.rs
+++ b/src/event.rs
@@ -32,34 +32,32 @@ pub fn handle_key_bindings(
             app.schedule.previous();
             let _ = selective_update.try_send(MenuItem::Scoreboard);
         }
-        (MenuItem::Scoreboard, Char(':')) => {
-            app.update_tab(MenuItem::DatePicker);
-        }
+        (MenuItem::Scoreboard, Char(':')) => app.update_tab(MenuItem::DatePicker),
+
         (MenuItem::DatePicker, KeyCode::Enter) => {
             app.update_tab(MenuItem::Scoreboard);
             let _ = selective_update.try_send(MenuItem::Scoreboard);
         }
-        (MenuItem::Standings, Char('j')) => {
-            app.standings.next();
-        }
-        (MenuItem::Standings, Char('k')) => {
-            app.standings.previous();
-        }
+        (MenuItem::DatePicker, KeyCode::Esc) => app.update_tab(MenuItem::Scoreboard),
+
+        (MenuItem::Standings, Char('j')) => app.standings.next(),
+        (MenuItem::Standings, Char('k')) => app.standings.previous(),
         (MenuItem::Standings, KeyCode::Enter) => {
             let team_id = app.standings.get_selected();
             println!("team id: {:?}", team_id);
             // TODO
         }
 
-        (_, Char('?')) => app.update_tab(MenuItem::Help),
-        (MenuItem::Help, KeyCode::Esc) => app.exit_help(),
-        (_, Char('d')) => app.toggle_debug(),
-
         (MenuItem::Gameday, Char('i')) => app.gameday.info = !app.gameday.info,
         (MenuItem::Gameday, Char('p')) => app.gameday.at_bat = !app.gameday.at_bat,
         (MenuItem::Gameday, Char('b')) => app.gameday.boxscore = !app.gameday.boxscore,
         (MenuItem::Gameday, Char('h')) => app.boxscore_tab = BoxscoreTab::Home,
         (MenuItem::Gameday, Char('a')) => app.boxscore_tab = BoxscoreTab::Away,
+
+        (_, Char('?')) => app.update_tab(MenuItem::Help),
+        (MenuItem::Help, KeyCode::Esc) => app.exit_help(),
+        (_, Char('d')) => app.toggle_debug(),
+
         _ => {}
     }
     let _ = request_redraw.try_send(());

--- a/src/event.rs
+++ b/src/event.rs
@@ -32,6 +32,13 @@ pub fn handle_key_bindings(
             app.schedule.previous();
             let _ = selective_update.try_send(MenuItem::Scoreboard);
         }
+        (MenuItem::Scoreboard, Char(':')) => {
+            app.update_tab(MenuItem::DatePicker);
+        }
+        (MenuItem::DatePicker, KeyCode::Enter) => {
+            app.update_tab(MenuItem::Scoreboard);
+            let _ = selective_update.try_send(MenuItem::Scoreboard);
+        }
         (MenuItem::Standings, Char('j')) => {
             app.standings.next();
         }
@@ -45,7 +52,7 @@ pub fn handle_key_bindings(
         }
 
         (_, Char('?')) => app.update_tab(MenuItem::Help),
-        (_, KeyCode::Esc) => app.exit_help(),
+        (MenuItem::Help, KeyCode::Esc) => app.exit_help(),
         (_, Char('d')) => app.toggle_debug(),
 
         (MenuItem::Gameday, Char('i')) => app.gameday.info = !app.gameday.info,

--- a/src/main.rs
+++ b/src/main.rs
@@ -54,6 +54,7 @@ fn main() -> Result<(), Box<dyn Error>> {
         active_tab: MenuItem::Scoreboard,
         previous_state: MenuItem::Scoreboard,
         schedule: ScheduleState::from_schedule(&CLIENT.get_todays_schedule()),
+        date_input: String::new(),
         standings: StandingsState::default(),
         live_game: GameState::new(),
         debug_state: DebugState::Off,
@@ -84,6 +85,13 @@ fn main() -> Result<(), Box<dyn Error>> {
                         // update linescore only when a different game is selected
                         Ok(MenuItem::Scoreboard) => {
                             // TODO replace live_data with linescore endpoint for speed
+                            let game_id = app.schedule.get_selected_game();
+                            app.update_live_data(&CLIENT.get_live_data(game_id));
+                        }
+                        // update schedule and linescore when a new date is picked
+                        Ok(MenuItem::DatePicker) => {
+                            let date = app.schedule.date;
+                            app.schedule.update(&CLIENT.get_schedule_date(date));
                             let game_id = app.schedule.get_selected_game();
                             app.update_live_data(&CLIENT.get_live_data(game_id));
                         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -100,7 +100,8 @@ fn main() -> Result<(), Box<dyn Error>> {
                     let mut app = app.lock().unwrap();
                     match app.active_tab {
                         MenuItem::Scoreboard => {
-                            app.schedule.update(&CLIENT.get_todays_schedule());
+                            let date = app.schedule.date;
+                            app.schedule.update(&CLIENT.get_schedule_date(date));
                             let game_id = app.schedule.get_selected_game();
                             app.update_live_data(&CLIENT.get_live_data(game_id));
                         },
@@ -112,6 +113,7 @@ fn main() -> Result<(), Box<dyn Error>> {
                             // Don't update the standings every 10 seconds, only on tab switch
                         },
                         MenuItem::Stats => {},
+                        MenuItem::DatePicker => {},
                         MenuItem::Help => {},
                     }
                     let _ = request_redraw.try_send(());

--- a/src/schedule.rs
+++ b/src/schedule.rs
@@ -27,7 +27,7 @@ impl ScheduleState {
         ss
     }
 
-    /// Update the date from the API. It is assumed that the date is already updated, aka don't use
+    /// Update the data from the API. It is assumed that the date is already updated, aka don't use
     /// a random date without first setting the `date` field. Use `set_date_from_input` for this.
     pub fn update(&mut self, schedule: &ScheduleResponse) {
         self.schedule.game_info = Schedule::create_table(schedule);

--- a/src/schedule.rs
+++ b/src/schedule.rs
@@ -27,10 +27,11 @@ impl ScheduleState {
         ss
     }
 
+    /// Update the date from the API. It is assumed that the date is already updated, aka don't use
+    /// a random date without first setting the `date` field. Use `set_date_from_input` for this.
     pub fn update(&mut self, schedule: &ScheduleResponse) {
         self.schedule.game_info = Schedule::create_table(schedule);
         self.schedule.game_ids = Schedule::get_game_pks(schedule);
-        self.date = Schedule::get_date_from_schedule(schedule);
     }
 
     /// Set the date from the input string from the date picker.
@@ -146,16 +147,20 @@ impl Schedule {
     fn get_date_from_schedule(schedule: &ScheduleResponse) -> NaiveDate {
         let now = Utc::now().naive_local();
         let now = NaiveDate::from_ymd(now.year(), now.month(), now.day());
-        match &schedule.dates[0].date {
-            None => now,
-            Some(d) => {
-                if let Ok(p) = NaiveDate::parse_from_str(d, "%Y-%m-%d") {
-                    p
-                } else {
-                    now
+        return if let Some(games) = &schedule.dates.get(0) {
+            match &games.date {
+                None => now,
+                Some(d) => {
+                    if let Ok(p) = NaiveDate::parse_from_str(d, "%Y-%m-%d") {
+                        p
+                    } else {
+                        now
+                    }
                 }
             }
-        }
+        } else {
+            now
+        };
     }
 }
 
@@ -178,6 +183,7 @@ lazy_static! {
         m.insert("Atlanta Braves", "Braves");
         m.insert("Chicago White Sox", "White Sox");
         m.insert("Miami Marlins", "Marlins");
+        m.insert("Florida Marlins", "Marlins");
         m.insert("New York Yankees", "Yankees");
         m.insert("Milwaukee Brewers", "Brewers");
         m.insert("Los Angeles Angels", "Angels");

--- a/src/schedule.rs
+++ b/src/schedule.rs
@@ -1,4 +1,4 @@
-use chrono::{DateTime, Datelike, NaiveDate, Utc};
+use chrono::{DateTime, Datelike, NaiveDate, ParseError, Utc};
 use chrono_tz::America::Los_Angeles;
 use core::option::Option::{None, Some};
 use lazy_static::lazy_static;
@@ -31,6 +31,16 @@ impl ScheduleState {
         self.schedule.game_info = Schedule::create_table(schedule);
         self.schedule.game_ids = Schedule::get_game_pks(schedule);
         self.date = Schedule::get_date_from_schedule(schedule);
+    }
+
+    /// Set the date from the input string from the date picker.
+    pub fn set_date_from_input(&mut self, date: String) -> Result<(), ParseError> {
+        match NaiveDate::parse_from_str(date.as_str(), "%Y-%m-%d") {
+            Ok(d) => self.date = d,
+            Err(err) => return Err(err),
+        };
+        self.state.select(Some(0));
+        Ok(())
     }
 
     pub fn get_selected_game(&self) -> u64 {

--- a/src/strikezone.rs
+++ b/src/strikezone.rs
@@ -12,8 +12,8 @@ pub const HOME_PLATE_WIDTH: f64 = 17.0; // inches
 const X_COORDS: [f64; 3] = [-8.5, 17.0 / -6.0, 17.0 / 6.0];
 
 /// The default strike zone bottom and top represent the horizontal bounds for the strike zone. They
-/// They are measured in feet from the ground. Note that the MLB considers this the z-axis (not y),
-/// with the ground being z = 0.
+/// are measured in feet from the ground. Note that the MLB considers this the z-axis (not y), with
+/// the ground being z = 0.
 pub const DEFAULT_SZ_BOT: f64 = 1.5; // feet
 pub const DEFAULT_SZ_TOP: f64 = 3.3; // feet
 
@@ -59,6 +59,9 @@ impl StrikeZone {
             None => return StrikeZone::default(),
         };
         // TODO set strike zone top/bottom here
+        if colors.len() < 9 {
+            return StrikeZone::default();
+        }
         StrikeZone::new(colors)
     }
 
@@ -73,9 +76,9 @@ impl StrikeZone {
             .collect()
     }
 
-    /// Builds the coordinates for the 3x3 heatmap. Each coordinate represents the upper left corner of
-    /// a heatmap zone. A tui-rs rectangle is then built from a coordinate; its positive X axis going
-    /// right, and positive Y axis going down, from the coordinate.
+    /// Builds the coordinates for the 3x3 heatmap. Each coordinate represents the upper left corner
+    /// of a heatmap zone. A tui-rs rectangle is then built from a coordinate; its positive X axis
+    /// going right, and positive Y axis going down, from the coordinate.
     pub fn build_coords(strike_zone_bot: f64, strike_zone_top: f64) -> Vec<Coordinate> {
         let y_chunk = (strike_zone_top - strike_zone_bot) / 3.0;
         let y_coords = vec![

--- a/src/ui/help.rs
+++ b/src/ui/help.rs
@@ -8,7 +8,7 @@ use tui::{
 use crate::banner::BANNER;
 
 const HEADER: &[&str; 2] = &["Description", "Key"];
-pub const DOCS_LEN: usize = 18;
+pub const DOCS_LEN: usize = 19;
 const DOCS: &[&[&str; 2]; DOCS_LEN] = &[
     &["Exit help", "Esc"],
     &["Quit", "q"],
@@ -19,6 +19,7 @@ const DOCS: &[&[&str; 2]; DOCS_LEN] = &[
     &["Scoreboard", ""],
     &["Move down", "j"],
     &["Move up", "k"],
+    &["Select date", ":"],
     &["Gameday", ""],
     &["Toggle game info", "i"],
     &["Toggle pitches", "p"],

--- a/src/ui/layout.rs
+++ b/src/ui/layout.rs
@@ -97,4 +97,33 @@ impl LayoutAreas {
             .constraints(constraints.as_slice())
             .split(area)
     }
+
+    /// Create a centered rectangle of 4 height and 42% width.
+    pub fn create_date_picker(area: Rect) -> Rect {
+        let height = 4;
+        let percent_width = 42;
+        let popup_layout = Layout::default()
+            .direction(Direction::Vertical)
+            .constraints(
+                [
+                    Constraint::Ratio(1, 2),
+                    Constraint::Length(height),
+                    Constraint::Ratio(1, 2),
+                ]
+                .as_ref(),
+            )
+            .split(area);
+
+        Layout::default()
+            .direction(Direction::Horizontal)
+            .constraints(
+                [
+                    Constraint::Percentage((100 - percent_width) / 2),
+                    Constraint::Percentage(percent_width),
+                    Constraint::Percentage((100 - percent_width) / 2),
+                ]
+                .as_ref(),
+            )
+            .split(popup_layout[1])[1]
+    }
 }

--- a/src/ui/layout.rs
+++ b/src/ui/layout.rs
@@ -78,7 +78,7 @@ impl LayoutAreas {
     }
 
     /// Create the Gameday layouts based on how many of the panels are active.
-    pub fn generate_layouts(active: &GamedayPanels, area: Rect) -> Vec<Rect> {
+    pub fn generate_gameday_panels(active: &GamedayPanels, area: Rect) -> Vec<Rect> {
         let constraints = match active.count() {
             0 | 1 => vec![Constraint::Percentage(100)],
             2 => vec![Constraint::Percentage(50), Constraint::Percentage(50)],

--- a/src/ui/schedule.rs
+++ b/src/ui/schedule.rs
@@ -33,7 +33,8 @@ impl StatefulWidget for ScheduleWidget {
             .block(
                 Block::default()
                     .borders(Borders::ALL)
-                    .border_type(BorderType::Rounded),
+                    .border_type(BorderType::Rounded)
+                    .title(state.date.format("%B %e, %Y").to_string()),
             )
             .highlight_style(selected_style)
             .highlight_symbol(">> ")

--- a/src/ui/schedule.rs
+++ b/src/ui/schedule.rs
@@ -34,7 +34,7 @@ impl StatefulWidget for ScheduleWidget {
                 Block::default()
                     .borders(Borders::ALL)
                     .border_type(BorderType::Rounded)
-                    .title(state.date.format("%B %e, %Y").to_string()),
+                    .title(state.date.format("%B %d, %Y").to_string()),
             )
             .highlight_style(selected_style)
             .highlight_symbol(">> ")


### PR DESCRIPTION
The user can bring up a date selection menu with `:` when viewing the `Scoreboard` tab. The date is then used to change the games displayed. This works going backwards and forwards - or viewing past games and checking the upcoming schedule.

After checking out some past dates I ran into a couple bugs. One was the team name had changed, and the other was some of the data expected by the `Gameday` tab wasn't present. I expect that there will be more bugs of this nature as old data will have unexpected differences. Besides scraping all past data, I don't see a great way to test this, so I'll fix these as they arise.

Closes issue #18 