### PR TITLE
Add loading spinner and completely change thread model

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -251,21 +251,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
-name = "crossbeam-channel"
-version = "0.5.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
-dependencies = [
- "crossbeam-utils",
-]
-
-[[package]]
-name = "crossbeam-utils"
-version = "0.8.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
-
-[[package]]
 name = "crossterm"
 version = "0.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1097,13 +1082,12 @@ dependencies = [
 
 [[package]]
 name = "mlbt"
-version = "0.0.15"
+version = "0.0.16-alpha.1"
 dependencies = [
  "anyhow",
  "better-panic",
  "chrono",
  "chrono-tz",
- "crossbeam-channel",
  "crossterm 0.29.0",
  "directories",
  "indexmap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mlbt"
-version = "0.0.15"
+version = "0.0.16-alpha.1"
 authors = ["Andrew Schneider <andjschneider@gmail.com>"]
 edition = "2024"
 
@@ -13,7 +13,6 @@ better-panic = "0.3.0"
 chrono = "0.4.41"
 chrono-tz = { version = "0.10.3", features = ["serde"] }
 crossterm = "0.29.0"
-crossbeam-channel = "0.5.15"
 directories = "6.0.0"
 indexmap = "2.9.0"
 mlb-api = { path = "api", version = "0.0.14" }

--- a/api/src/client.rs
+++ b/api/src/client.rs
@@ -3,7 +3,7 @@ use std::fmt;
 use crate::live::LiveResponse;
 use crate::schedule::ScheduleResponse;
 use crate::standings::StandingsResponse;
-use crate::stats::StatResponse;
+use crate::stats::StatsResponse;
 
 use chrono::{DateTime, Datelike, Local, NaiveDate};
 use derive_builder::Builder;
@@ -100,7 +100,7 @@ impl MLBApi {
         self.get(url).await
     }
 
-    pub async fn get_team_stats(&self, group: StatGroup) -> StatResponse {
+    pub async fn get_team_stats(&self, group: StatGroup) -> StatsResponse {
         let local: DateTime<Local> = Local::now();
         let url = format!(
             "{}v1/teams/stats?sportId=1&stats=season&season={}&group={}",
@@ -111,7 +111,7 @@ impl MLBApi {
         self.get(url).await
     }
 
-    pub async fn get_team_stats_on_date(&self, group: StatGroup, date: NaiveDate) -> StatResponse {
+    pub async fn get_team_stats_on_date(&self, group: StatGroup, date: NaiveDate) -> StatsResponse {
         let url = format!(
             "{}v1/teams/stats?sportId=1&stats=byDateRange&season={}&endDate={}&group={}",
             self.base_url,
@@ -122,7 +122,7 @@ impl MLBApi {
         self.get(url).await
     }
 
-    pub async fn get_player_stats(&self, group: StatGroup) -> StatResponse {
+    pub async fn get_player_stats(&self, group: StatGroup) -> StatsResponse {
         let local: DateTime<Local> = Local::now();
         let url = format!(
             "{}v1/stats?sportId=1&stats=season&season={}&group={}",
@@ -137,7 +137,7 @@ impl MLBApi {
         &self,
         group: StatGroup,
         date: NaiveDate,
-    ) -> StatResponse {
+    ) -> StatsResponse {
         let url = format!(
             "{}v1/stats?sportId=1&stats=byDateRange&season={}&endDate={}&group={}",
             self.base_url,

--- a/api/src/stats.rs
+++ b/api/src/stats.rs
@@ -2,7 +2,7 @@ use crate::schedule::IdNameLink;
 use serde::{Deserialize, Serialize};
 
 #[derive(Default, Debug, Serialize, Deserialize)]
-pub struct StatResponse {
+pub struct StatsResponse {
     pub stats: Vec<Stat>,
 }
 

--- a/src/components/date_selector.rs
+++ b/src/components/date_selector.rs
@@ -17,13 +17,6 @@ impl Default for DateSelector {
 }
 
 impl DateSelector {
-    pub fn new(date: NaiveDate) -> Self {
-        Self {
-            date,
-            selection_offset: 0,
-        }
-    }
-
     /// Set the date from the validated input string from the date picker.
     pub fn set_date_from_valid_input(&mut self, date: NaiveDate) {
         self.date = date;

--- a/src/components/debug.rs
+++ b/src/components/debug.rs
@@ -3,7 +3,7 @@ use std::fmt;
 use tui::Frame;
 
 pub struct DebugInfo {
-    pub game_id: u64,
+    pub game_id: Option<u64>,
     pub gameday_url: String,
     pub terminal_width: u16,
     pub terminal_height: u16,
@@ -14,8 +14,8 @@ impl fmt::Display for DebugInfo {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(
             f,
-            "game id: {}\ngameday: {}\nterminal height: {} width: {}\n{:?}",
-            self.game_id,
+            "game id: {}, gameday: {}\nterminal height: {} width: {}\n{:?}",
+            self.game_id.unwrap_or_default(),
             self.gameday_url,
             self.terminal_height,
             self.terminal_width,
@@ -27,7 +27,7 @@ impl fmt::Display for DebugInfo {
 impl DebugInfo {
     pub fn new() -> Self {
         DebugInfo {
-            game_id: 0,
+            game_id: None,
             gameday_url: "https://www.mlb.com/scores".to_string(),
             terminal_width: 0,
             terminal_height: 0,
@@ -38,8 +38,11 @@ impl DebugInfo {
     // - last api call time
     // - other things?
     pub fn gather_info(&mut self, f: &Frame, app: &App) {
-        self.game_id = app.state.schedule.get_selected_game();
-        self.gameday_url = format!("https://www.mlb.com/gameday/{}", self.game_id);
+        self.game_id = app.state.schedule.get_selected_game_opt();
+        self.gameday_url = format!(
+            "https://www.mlb.com/gameday/{}",
+            self.game_id.unwrap_or_default()
+        );
         self.terminal_width = f.area().width;
         self.terminal_height = f.area().height;
         self.gameday_active_views = app.state.gameday;

--- a/src/components/live_game.rs
+++ b/src/components/live_game.rs
@@ -7,6 +7,7 @@ use mlb_api::live::LiveResponse;
 
 #[derive(Default)]
 pub struct GameState {
+    pub current_game_id: u64,
     pub linescore: LineScore,
     pub at_bat: AtBat,
     pub boxscore: TeamBatterBoxscore,
@@ -16,10 +17,28 @@ pub struct GameState {
 
 impl GameState {
     pub fn update(&mut self, live_data: &LiveResponse) {
+        self.current_game_id = live_data.game_pk;
         self.linescore = LineScore::from_live_data(live_data);
         self.at_bat = AtBat::from_live_data(live_data);
         self.boxscore = TeamBatterBoxscore::from_live_data(live_data);
         self.matchup = Matchup::from_live_data(live_data);
         self.plays = InningPlays::from_live_data(live_data);
+    }
+
+    pub fn clear(&mut self) {
+        self.current_game_id = 0;
+        self.linescore = LineScore::default();
+        self.at_bat = AtBat::default();
+        self.boxscore = TeamBatterBoxscore::default();
+        self.matchup = Matchup::default();
+        self.plays = InningPlays::default();
+    }
+
+    pub fn get_current_game_id(&self) -> u64 {
+        self.current_game_id
+    }
+
+    pub fn set_game_id(&mut self, game_id: u64) {
+        self.current_game_id = game_id;
     }
 }

--- a/src/components/stats.rs
+++ b/src/components/stats.rs
@@ -2,7 +2,7 @@ use crate::components::date_selector::DateSelector;
 use chrono::NaiveDate;
 use indexmap::IndexMap;
 use mlb_api::client::StatGroup;
-use mlb_api::stats::{HittingStat, PitchingStat, StatResponse, StatSplit};
+use mlb_api::stats::{HittingStat, PitchingStat, StatSplit, StatsResponse};
 use std::cmp::Ordering;
 use std::string::ToString;
 use tui::widgets::TableState;
@@ -15,13 +15,13 @@ const PLAYER_COLUMN_NAME: &str = "Player";
 const TEAM_COLUMN_NAME: &str = "Team";
 
 /// Stores whether a team/player and pitching/hitting stat should be viewed.
-#[derive(Clone, Debug)]
+#[derive(Clone, Copy, Debug)]
 pub struct StatType {
     pub group: StatGroup,
     pub team_player: TeamOrPlayer,
 }
 
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Copy, Debug, Default)]
 pub enum TeamOrPlayer {
     #[default]
     Team,
@@ -118,7 +118,7 @@ impl Default for StatsState {
 }
 
 impl StatsState {
-    pub fn update(&mut self, stats: &StatResponse) {
+    pub fn update(&mut self, stats: &StatsResponse) {
         self.stats.clear();
         self.create_table(stats);
     }
@@ -134,7 +134,7 @@ impl StatsState {
         self.date_selector.set_date_with_arrows(forward)
     }
 
-    fn create_table(&mut self, stats: &StatResponse) {
+    fn create_table(&mut self, stats: &StatsResponse) {
         for stat in &stats.stats {
             for split in &stat.splits {
                 // if the `player` field exists, then its a Player stat

--- a/src/draw.rs
+++ b/src/draw.rs
@@ -7,6 +7,7 @@ use tui::{Frame, Terminal};
 
 use crate::app::{App, DebugState, MenuItem};
 use crate::components::debug::DebugInfo;
+use crate::network::LoadingState;
 use crate::ui::at_bat::AtBatWidget;
 use crate::ui::boxscore::TeamBatterBoxscoreWidget;
 use crate::ui::date_selector::DateSelectorWidget;
@@ -21,7 +22,7 @@ use crate::ui::stats::{STATS_OPTIONS_WIDTH, StatsWidget};
 
 static TABS: &[&str; 4] = &["Scoreboard", "Gameday", "Stats", "Standings"];
 
-pub fn draw<B>(terminal: &mut Terminal<B>, app: &mut App)
+pub fn draw<B>(terminal: &mut Terminal<B>, app: &mut App, is_loading: LoadingState)
 where
     B: Backend,
 {
@@ -37,7 +38,7 @@ where
             main_layout.update(f.area(), app.settings.full_screen);
 
             if !app.settings.full_screen {
-                draw_tabs(f, &main_layout.top_bar, app);
+                draw_tabs(f, &main_layout.top_bar, app, is_loading);
             }
 
             match app.state.active_tab {
@@ -73,7 +74,7 @@ fn draw_border(f: &mut Frame, rect: Rect, color: Color) {
     f.render_widget(block, rect);
 }
 
-fn draw_tabs(f: &mut Frame, top_bar: &[Rect], app: &App) {
+fn draw_tabs(f: &mut Frame, top_bar: &[Rect], app: &App, loading: LoadingState) {
     let style = Style::default().fg(Color::White);
     let border_style = Style::default();
     let border_type = BorderType::Rounded;
@@ -95,7 +96,9 @@ fn draw_tabs(f: &mut Frame, top_bar: &[Rect], app: &App) {
         .style(style);
     f.render_widget(tabs, top_bar[0]);
 
-    let help = Paragraph::new("Help: ? ")
+    // display animated spinner if there are API requests in progress
+    let text = format!("{} Help: ? ", loading.spinner_char);
+    let help = Paragraph::new(text)
         .alignment(Alignment::Right)
         .block(
             Block::default()

--- a/src/messages.rs
+++ b/src/messages.rs
@@ -1,0 +1,56 @@
+use crate::components::stats::StatType;
+use crate::network::LoadingState;
+use chrono::NaiveDate;
+use crossterm::event::KeyEvent;
+use mlb_api::live::LiveResponse;
+use mlb_api::schedule::ScheduleResponse;
+use mlb_api::standings::StandingsResponse;
+use mlb_api::stats::StatsResponse;
+
+#[derive(Debug, Clone)]
+pub enum NetworkRequest {
+    Schedule {
+        date: NaiveDate,
+    },
+    GameData {
+        game_id: u64,
+    },
+    Standings {
+        date: NaiveDate,
+    },
+    Stats {
+        date: NaiveDate,
+        stat_type: StatType,
+    },
+}
+
+#[derive(Debug)]
+pub enum NetworkResponse {
+    LoadingStateChanged {
+        loading_state: LoadingState,
+    },
+    ScheduleLoaded {
+        schedule: ScheduleResponse,
+    },
+    GameDataLoaded {
+        game: Box<LiveResponse>,
+    },
+    StandingsLoaded {
+        standings: StandingsResponse,
+    },
+    StatsLoaded {
+        stats: StatsResponse,
+    },
+    // TODO pass through errors from API
+    #[allow(dead_code)]
+    Error {
+        message: String,
+    },
+}
+
+#[derive(Debug, Clone)]
+pub enum UiEvent {
+    KeyPressed(KeyEvent),
+    Resize,
+    AppStarted,
+}

--- a/src/network.rs
+++ b/src/network.rs
@@ -1,0 +1,154 @@
+use crate::components::stats::{StatType, TeamOrPlayer};
+use crate::messages::{NetworkRequest, NetworkResponse};
+use chrono::NaiveDate;
+use mlb_api::client::{MLBApi, MLBApiBuilder};
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::time::Duration;
+use tokio::sync::mpsc;
+
+const SPINNER_CHARS: [char; 10] = ['⠋', '⠙', '⠹', '⠸', '⠼', '⠴', '⠦', '⠧', '⠇', '⠏'];
+
+#[derive(Debug, Copy, Clone)]
+pub struct LoadingState {
+    pub is_loading: bool,
+    pub spinner_char: char,
+}
+
+impl Default for LoadingState {
+    fn default() -> Self {
+        Self {
+            is_loading: false,
+            spinner_char: ' ',
+        }
+    }
+}
+
+pub struct NetworkWorker {
+    client: MLBApi,
+    requests: mpsc::Receiver<NetworkRequest>,
+    responses: mpsc::Sender<NetworkResponse>,
+    is_loading: Arc<AtomicBool>,
+}
+
+impl NetworkWorker {
+    pub fn new(
+        requests: mpsc::Receiver<NetworkRequest>,
+        responses: mpsc::Sender<NetworkResponse>,
+    ) -> Self {
+        Self {
+            client: MLBApiBuilder::default().build().unwrap(),
+            requests,
+            responses,
+            is_loading: Arc::new(AtomicBool::new(false)),
+        }
+    }
+
+    pub async fn run(mut self) {
+        while let Some(request) = self.requests.recv().await {
+            self.start_loading_animation().await;
+            let response = match request {
+                NetworkRequest::Schedule { date } => self.handle_load_schedule(date).await,
+                NetworkRequest::GameData { game_id } => self.handle_load_game_data(game_id).await,
+                NetworkRequest::Standings { date } => self.handle_load_standings(date).await,
+                NetworkRequest::Stats { date, stat_type } => {
+                    self.handle_load_stats(date, stat_type).await
+                }
+            };
+            self.stop_loading_animation().await;
+
+            if let Some(response) = response {
+                if let Err(e) = self.responses.send(response).await {
+                    eprintln!("Failed to send network response: {}", e);
+                    break;
+                }
+            }
+        }
+    }
+
+    async fn handle_load_schedule(&self, date: NaiveDate) -> Option<NetworkResponse> {
+        let schedule = self.client.get_schedule_date(date).await;
+        Some(NetworkResponse::ScheduleLoaded { schedule })
+    }
+
+    async fn handle_load_game_data(&self, game_id: u64) -> Option<NetworkResponse> {
+        let game = self.client.get_live_data(game_id).await;
+        Some(NetworkResponse::GameDataLoaded {
+            game: Box::new(game),
+        })
+    }
+
+    async fn handle_load_standings(&self, date: NaiveDate) -> Option<NetworkResponse> {
+        let standings = self.client.get_standings(date).await;
+        Some(NetworkResponse::StandingsLoaded { standings })
+    }
+
+    async fn handle_load_stats(
+        &self,
+        date: NaiveDate,
+        stat_type: StatType,
+    ) -> Option<NetworkResponse> {
+        let StatType { team_player, group } = stat_type;
+        let stats = match team_player {
+            TeamOrPlayer::Team => self.client.get_team_stats_on_date(group, date).await,
+            TeamOrPlayer::Player => self.client.get_player_stats_on_date(group, date).await,
+        };
+        Some(NetworkResponse::StatsLoaded { stats })
+    }
+
+    async fn start_loading_animation(&self) {
+        self.is_loading.store(true, Ordering::Relaxed);
+
+        // Send initial loading state
+        let mut loading_state = LoadingState {
+            is_loading: true,
+            spinner_char: SPINNER_CHARS[0],
+        };
+        let _ = self
+            .responses
+            .send(NetworkResponse::LoadingStateChanged { loading_state })
+            .await;
+
+        // Spawn a background task for spinner animation
+        let responses = self.responses.clone();
+        let is_loading = self.is_loading.clone();
+
+        tokio::spawn(async move {
+            let mut spinner_index = 1;
+            // 30 FPS animation
+            let mut interval = tokio::time::interval(Duration::from_millis(33));
+
+            loop {
+                interval.tick().await;
+
+                // Check loading state before sending update and exit immediately when loading stops
+                if !is_loading.load(Ordering::Relaxed) {
+                    break;
+                }
+
+                let spinner_char = SPINNER_CHARS[spinner_index];
+                spinner_index = (spinner_index + 1) % SPINNER_CHARS.len();
+                loading_state.spinner_char = spinner_char;
+
+                // Send spinner update to UI
+                let _ = responses
+                    .send(NetworkResponse::LoadingStateChanged { loading_state })
+                    .await;
+            }
+        });
+    }
+
+    async fn stop_loading_animation(&self) {
+        self.is_loading.store(false, Ordering::Relaxed);
+
+        // Add a small delay to ensure the animation task stops
+        tokio::time::sleep(Duration::from_millis(15)).await;
+
+        let _ = self
+            .responses
+            .send(NetworkResponse::LoadingStateChanged {
+                loading_state: LoadingState::default(),
+            })
+            .await;
+    }
+}

--- a/src/refresher.rs
+++ b/src/refresher.rs
@@ -1,0 +1,61 @@
+use crate::app::{App, MenuItem};
+use crate::messages::NetworkRequest;
+use std::time::Duration;
+use tokio::sync::mpsc;
+use tokio::time::interval;
+
+pub struct PeriodicRefresher {
+    network_requests: mpsc::Sender<NetworkRequest>,
+}
+
+impl PeriodicRefresher {
+    pub fn new(network_requests: mpsc::Sender<NetworkRequest>) -> Self {
+        Self { network_requests }
+    }
+
+    pub async fn run(self, app: std::sync::Arc<tokio::sync::Mutex<App>>) {
+        let mut live_interval = interval(Duration::from_secs(10)); // Live data every 10s
+        let mut schedule_interval = interval(Duration::from_secs(300)); // Schedule every 5 minutes
+        let mut standings_interval = interval(Duration::from_secs(1800)); // Standings every 30 minutes
+
+        loop {
+            tokio::select! {
+                // Live game data updates (frequent for active games)
+                _ = live_interval.tick() => {
+                    let (active_tab, game_id) = {
+                        let app = app.lock().await;
+                        (app.state.active_tab, app.state.live_game.get_current_game_id())
+                    };
+
+                    if active_tab == MenuItem::Gameday {
+                        let _ = self.network_requests.send(NetworkRequest::GameData { game_id }).await;
+                    }
+                }
+
+                // Schedule updates (moderate frequency)
+                _ = schedule_interval.tick() => {
+                    let (active_tab, date) = {
+                        let app = app.lock().await;
+                        (app.state.active_tab, app.state.schedule.date_selector.date)
+                    };
+
+                    if active_tab == MenuItem::Scoreboard {
+                        let _ = self.network_requests.send(NetworkRequest::Schedule { date }).await;
+                    }
+                }
+
+                // Standings updates (low frequency)
+                _ = standings_interval.tick() => {
+                    let (active_tab, date) = {
+                        let app = app.lock().await;
+                        (app.state.active_tab, app.state.standings.date_selector.date)
+                    };
+
+                    if active_tab == MenuItem::Standings {
+                        let _ = self.network_requests.send(NetworkRequest::Standings { date }).await;
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
This add a loading spinner in the upper right corner that spins when API calls are in flight.

![loading-spinner](https://github.com/user-attachments/assets/06653c04-bf19-497d-8095-ebd62580c278)

This was actually really hard with the old async model I had, so I basically had to rewrite it. It should be faster now since rendering and API threads are completely separate