### PR TITLE
Sort standings by favorite team

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,23 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Changed
+
+- Standings are now sorted by the configured favorite team, so the division with
+  the team is always shown first. Additionally, the favorite team is 
+  automatically selected and highlighted. [PR 57](https://github.com/mlb-rs/mlbt/pull/57)
+
+### Added
+
+- Add a spinning loader when API calls are in flight: [PR 56](https://github.com/mlb-rs/mlbt/pull/56)
+
 ## [0.0.15] - 2025-06-03
 
-## Fixed
+### Fixed
 
-- Error in team stats API response parsing introduced by the date selection update.
+- Error in team stats API response parsing introduced by the date selection update
 
 ## [0.0.14] - 2025-05-31
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -1,6 +1,6 @@
 use crate::components::live_game::GameState;
 use crate::components::schedule::ScheduleState;
-use crate::components::standings::StandingsState;
+use crate::components::standings::{StandingsState, Team};
 use crate::components::stats::StatsState;
 use crate::config::ConfigFile;
 use chrono::{NaiveDate, ParseError, Utc};
@@ -64,7 +64,7 @@ pub struct AppState {
 
 #[derive(Debug, Default, Clone)]
 pub struct AppSettings {
-    pub favorite_team: Option<String>,
+    pub favorite_team: Option<Team>,
     pub full_screen: bool,
     pub timezone: Tz,
     pub timezone_abbreviation: String,
@@ -100,6 +100,7 @@ impl App {
     /// Run any final configuration that might need to access multiple parts of state.
     fn configure(&mut self) {
         self.set_all_datepickers_to_today();
+        self.state.standings.favorite_team = self.settings.favorite_team;
     }
 
     /// Sync date pickers using the correct timezone.
@@ -134,6 +135,10 @@ impl App {
             self.state.previous_tab = self.state.active_tab;
             self.state.active_tab = next;
             self.state.debug_state = DebugState::Off;
+        }
+        // reset selection when switching tabs but not when date picker is opened
+        if next != MenuItem::DatePicker && self.state.previous_tab == MenuItem::Standings {
+            self.state.standings.reset_selection();
         }
     }
 

--- a/src/components/constants.rs
+++ b/src/components/constants.rs
@@ -1,9 +1,10 @@
+use crate::components::standings::Team;
 use std::collections::HashMap;
 use std::sync::LazyLock;
 
 /// This maps the `teamId` to the `shortName` for each division and league.
 /// The team names are taken from the `divisions` endpoint.
-pub static DIVISIONS: LazyLock<HashMap<u8, &'static str>> = LazyLock::new(|| {
+pub static DIVISIONS: LazyLock<HashMap<u16, &'static str>> = LazyLock::new(|| {
     HashMap::from([
         (103, "American League"),
         (104, "National League"),
@@ -13,6 +14,19 @@ pub static DIVISIONS: LazyLock<HashMap<u8, &'static str>> = LazyLock::new(|| {
         (203, "NL West"),
         (204, "NL East"),
         (205, "NL Central"),
+    ])
+});
+
+/// This is a map of the order divisions should be shown in the standings view, keyed by the
+/// users' favorite team's division.
+pub static DIVISION_ORDERS: LazyLock<HashMap<u16, Vec<u16>>> = LazyLock::new(|| {
+    HashMap::from([
+        (200, vec![200, 201, 202, 203, 204, 205]),
+        (201, vec![201, 202, 200, 203, 204, 205]),
+        (202, vec![202, 200, 201, 203, 204, 205]),
+        (203, vec![203, 204, 205, 200, 201, 202]),
+        (204, vec![204, 205, 203, 200, 201, 202]),
+        (205, vec![205, 203, 204, 200, 201, 202]),
     ])
 });
 
@@ -56,4 +70,44 @@ pub static TEAM_NAMES: LazyLock<HashMap<&'static str, &'static str>> = LazyLock:
         ("American League All-Stars", "AL All-Stars"),
         ("National League All-Stars", "NL All-Stars"),
     ])
+});
+
+#[rustfmt::skip]
+// TODO generate from json?
+pub static TEAM_IDS: LazyLock<HashMap<&'static str, Team>> = LazyLock::new(|| {
+    let mut m = HashMap::new();
+    m.insert("Oakland Athletics", Team { id: 133, division_id: 200, name: "Athletics", team_name: "Athletics", abbreviation: "ATH" });
+    m.insert("Athletics", Team { id: 133, division_id: 200, name: "Athletics", team_name: "Athletics", abbreviation: "ATH" });
+    m.insert("Pittsburgh Pirates", Team { id: 134, division_id: 205, name: "Pittsburgh Pirates", team_name: "Pirates", abbreviation: "PIT" });
+    m.insert("San Diego Padres", Team { id: 135, division_id: 203, name: "San Diego Padres", team_name: "Padres", abbreviation: "SD" });
+    m.insert("Seattle Mariners", Team { id: 136, division_id: 200, name: "Seattle Mariners", team_name: "Mariners", abbreviation: "SEA" });
+    m.insert("San Francisco Giants", Team { id: 137, division_id: 203, name: "San Francisco Giants", team_name: "Giants", abbreviation: "SF" });
+    m.insert("St. Louis Cardinals", Team { id: 138, division_id: 205, name: "St. Louis Cardinals", team_name: "Cardinals", abbreviation: "STL" });
+    m.insert("Tampa Bay Rays", Team { id: 139, division_id: 201, name: "Tampa Bay Rays", team_name: "Rays", abbreviation: "TB" });
+    m.insert("Texas Rangers", Team { id: 140, division_id: 200, name: "Texas Rangers", team_name: "Rangers", abbreviation: "TEX" });
+    m.insert("Toronto Blue Jays", Team { id: 141, division_id: 201, name: "Toronto Blue Jays", team_name: "Blue Jays", abbreviation: "TOR" });
+    m.insert("Minnesota Twins", Team { id: 142, division_id: 202, name: "Minnesota Twins", team_name: "Twins", abbreviation: "MIN" });
+    m.insert("Philadelphia Phillies", Team { id: 143, division_id: 204, name: "Philadelphia Phillies", team_name: "Phillies", abbreviation: "PHI" });
+    m.insert("Atlanta Braves", Team { id: 144, division_id: 204, name: "Atlanta Braves", team_name: "Braves", abbreviation: "ATL" });
+    m.insert("Chicago White Sox", Team { id: 145, division_id: 202, name: "Chicago White Sox", team_name: "White Sox", abbreviation: "CWS" });
+    m.insert("Florida Marlins", Team { id: 146, division_id: 204, name: "Miami Marlins", team_name: "Marlins", abbreviation: "MIA" });
+    m.insert("Miami Marlins", Team { id: 146, division_id: 204, name: "Miami Marlins", team_name: "Marlins", abbreviation: "MIA" });
+    m.insert("New York Yankees", Team { id: 147, division_id: 201, name: "New York Yankees", team_name: "Yankees", abbreviation: "NYY" });
+    m.insert("Milwaukee Brewers", Team { id: 158, division_id: 205, name: "Milwaukee Brewers", team_name: "Brewers", abbreviation: "MIL" });
+    m.insert("Los Angeles Angels", Team { id: 108, division_id: 200, name: "Los Angeles Angels", team_name: "Angels", abbreviation: "LAA" });
+    m.insert("Arizona Diamondbacks", Team { id: 109, division_id: 203, name: "Arizona Diamondbacks", team_name: "D-backs", abbreviation: "AZ" });
+    m.insert("Baltimore Orioles", Team { id: 110, division_id: 201, name: "Baltimore Orioles", team_name: "Orioles", abbreviation: "BAL" });
+    m.insert("Boston Red Sox", Team { id: 111, division_id: 201, name: "Boston Red Sox", team_name: "Red Sox", abbreviation: "BOS" });
+    m.insert("Chicago Cubs", Team { id: 112, division_id: 205, name: "Chicago Cubs", team_name: "Cubs", abbreviation: "CHC" });
+    m.insert("Cincinnati Reds", Team { id: 113, division_id: 205, name: "Cincinnati Reds", team_name: "Reds", abbreviation: "CIN" });
+    m.insert("Cleveland Indians", Team { id: 114, division_id: 202, name: "Cleveland Guardians", team_name: "Guardians", abbreviation: "CLE" });
+    m.insert("Cleveland Guardians", Team { id: 114, division_id: 202, name: "Cleveland Guardians", team_name: "Guardians", abbreviation: "CLE" });
+    m.insert("Colorado Rockies", Team { id: 115, division_id: 203, name: "Colorado Rockies", team_name: "Rockies", abbreviation: "COL" });
+    m.insert("Detroit Tigers", Team { id: 116, division_id: 202, name: "Detroit Tigers", team_name: "Tigers", abbreviation: "DET" });
+    m.insert("Houston Astros", Team { id: 117, division_id: 200, name: "Houston Astros", team_name: "Astros", abbreviation: "HOU" });
+    m.insert("Kansas City Royals", Team { id: 118, division_id: 202, name: "Kansas City Royals", team_name: "Royals", abbreviation: "KC" });
+    m.insert("Los Angeles Dodgers", Team { id: 119, division_id: 203, name: "Los Angeles Dodgers", team_name: "Dodgers", abbreviation: "LAD" });
+    m.insert("Washington Nationals", Team { id: 120, division_id: 204, name: "Washington Nationals", team_name: "Nationals", abbreviation: "WSH" });
+    m.insert("New York Mets", Team { id: 121, division_id: 204, name: "New York Mets", team_name: "Mets", abbreviation: "NYM" });
+    m
 });

--- a/src/components/schedule.rs
+++ b/src/components/schedule.rs
@@ -158,8 +158,8 @@ impl ScheduleRow {
         if let Some(games) = &schedule.dates.first() {
             let favorite = settings
                 .favorite_team
-                .clone()
-                .unwrap_or_else(|| "na".to_string());
+                .map(|f| f.name)
+                .unwrap_or_else(|| "na");
             if let Some(game) = &games.games {
                 for g in game {
                     let row = ScheduleRow::create_matchup(g, settings.timezone);

--- a/src/components/standings.rs
+++ b/src/components/standings.rs
@@ -1,29 +1,47 @@
-use crate::components::constants::DIVISIONS;
+use crate::components::constants::{DIVISION_ORDERS, DIVISIONS};
 use crate::components::date_selector::DateSelector;
 use chrono::NaiveDate;
-use core::option::Option::{None, Some};
+use core::option::Option::Some;
 use mlb_api::standings::{StandingsResponse, TeamRecord};
+use std::collections::HashSet;
 use tui::widgets::TableState;
 
 /// Stores the state for rendering the standings. The `standings` field is a nested Vec to make
 /// displaying by division easier.
 pub struct StandingsState {
     pub state: TableState,
+    pub favorite_team: Option<Team>,
     pub standings: Vec<Division>,
     pub team_ids: Vec<u16>,
     pub date_selector: DateSelector,
+    /// Used to skip selecting division names in the table.
+    division_row_indices: HashSet<usize>,
 }
 
 /// Groups teams into their divisions.
 pub struct Division {
     pub name: String,
-    id: u8,
+    pub id: u16,
     pub standings: Vec<Standing>,
+}
+
+#[derive(Debug, Clone, Copy)]
+#[allow(dead_code)]
+pub struct Team {
+    pub id: u16,
+    pub division_id: u16,
+    /// Full name, e.g. "Chicago Cubs"
+    pub name: &'static str,
+    /// Short name, e.g. "Cubs"
+    pub team_name: &'static str,
+    /// All caps abbreviation, e.g. "CHC"
+    pub abbreviation: &'static str,
 }
 
 /// Standing information per team.
 #[derive(Debug, Default)]
 pub struct Standing {
+    // pub team: Team, // TODO
     pub team_name: String,
     pub team_id: u16,
     pub wins: u8,
@@ -36,28 +54,42 @@ pub struct Standing {
 
 impl Default for StandingsState {
     fn default() -> Self {
-        let mut ss = StandingsState {
+        Self {
             state: TableState::default(),
             standings: Division::create_divisions(),
             team_ids: vec![200, 201, 202, 203, 204, 205],
             date_selector: DateSelector::default(),
-        };
-        ss.state.select(Some(0));
-        ss
+            division_row_indices: HashSet::new(),
+            favorite_team: None,
+        }
     }
 }
 
 impl StandingsState {
     /// Update the data from the API.
     pub fn update(&mut self, standings: &StandingsResponse) {
-        self.standings = Division::create_table(standings);
+        self.standings = Division::create_table(standings, self.favorite_team);
         self.team_ids = self.generate_ids();
+
+        if self.standings.is_empty() {
+            self.state.select(None);
+        } else {
+            self.reset_selection();
+        }
+    }
+
+    pub fn reset_selection(&mut self) {
+        if let Some(team) = self.favorite_team {
+            self.select_favorite_team(team)
+        } else if !self.team_ids.is_empty() {
+            let offset = 1; // TODO this should be 0 if the standings are pre 1969 since they don't have divisions
+            self.state.select(Some(offset));
+        }
     }
 
     /// Set the date from the validated input string from the date picker.
     pub fn set_date_from_valid_input(&mut self, date: NaiveDate) {
         self.date_selector.set_date_from_valid_input(date);
-        self.state.select(Some(0));
     }
 
     /// Set the date using Left/Right arrow keys to move a single day at a time.
@@ -67,53 +99,97 @@ impl StandingsState {
 
     fn generate_ids(&mut self) -> Vec<u16> {
         let mut ids = Vec::with_capacity(36); // 30 teams, 6 divisions
+        self.division_row_indices.clear(); // clear previous indices in case they change, e.g. historical standings
+
+        let mut count = 0;
         for division in &self.standings {
-            ids.push(division.id as u16);
+            ids.push(division.id);
+            self.division_row_indices.insert(count);
             for team in &division.standings {
                 ids.push(team.team_id);
             }
+            count += 1 + division.standings.len();
         }
         ids
     }
 
+    fn select_favorite_team(&mut self, team: Team) {
+        let idx = self
+            .standings
+            .iter()
+            .flat_map(|division| division.standings.iter())
+            .enumerate()
+            .find(|(_idx, standing)| standing.team_name == team.name)
+            .map(|(idx, _standing)| idx + 1);
+
+        self.state.select(idx);
+    }
+
     pub fn get_selected(&self) -> u16 {
-        if let Some(s) = self.team_ids.get(
-            self.state
-                .selected()
-                .expect("there is always a selected standing"),
-        ) {
+        let selected = self.state.selected().unwrap_or(0);
+        if let Some(s) = self.team_ids.get(selected) {
             *s
         } else {
             0
         }
     }
 
+    fn skip_division(&self, index: usize) -> bool {
+        self.division_row_indices.contains(&index)
+    }
+
+    fn move_forward(&self, current: usize) -> usize {
+        let len = self.team_ids.len();
+        if current >= len - 1 { 0 } else { current + 1 }
+    }
+
+    fn move_backward(&self, current: usize) -> usize {
+        let len = self.team_ids.len();
+        if current == 0 { len - 1 } else { current - 1 }
+    }
+
     pub fn next(&mut self) {
-        let i = match self.state.selected() {
-            Some(i) => {
-                if i >= self.team_ids.len() - 1 {
-                    0
-                } else {
-                    i + 1
-                }
-            }
-            None => 0,
-        };
+        let len = self.team_ids.len();
+        if len == 0 {
+            return;
+        }
+
+        let start = self.state.selected().unwrap_or(0);
+        let mut i = self.move_forward(start);
+
+        if self.skip_division(i) {
+            i = self.move_forward(i);
+        }
+
         self.state.select(Some(i));
+
+        // Reset offset when wrapping to beginning
+        if i < start {
+            self.state = TableState::default();
+            self.state.select(Some(i));
+        }
     }
 
     pub fn previous(&mut self) {
-        let i = match self.state.selected() {
-            Some(i) => {
-                if i == 0 {
-                    self.team_ids.len() - 1
-                } else {
-                    i - 1
-                }
-            }
-            None => 0,
-        };
+        let len = self.team_ids.len();
+        if len == 0 {
+            return;
+        }
+
+        let start = self.state.selected().unwrap_or(0);
+        let mut i = self.move_backward(start);
+
+        if self.skip_division(i) {
+            i = self.move_backward(i);
+        }
+
         self.state.select(Some(i));
+
+        // Reset offset when wrapping to end
+        if i > start {
+            self.state = TableState::default();
+            self.state.select(Some(i));
+        }
     }
 }
 
@@ -130,13 +206,13 @@ impl Division {
     }
 
     /// Generate the standings data to be used to render a table widget.
-    fn create_table(standings: &StandingsResponse) -> Vec<Division> {
+    fn create_table(standings: &StandingsResponse, favorite_team: Option<Team>) -> Vec<Division> {
         let mut s: Vec<Division> = standings
             .records
             .iter()
             .map(|r| Division {
-                name: DIVISIONS.get(&r.division.id).unwrap().to_string(),
-                id: r.division.id,
+                name: DIVISIONS.get(&(r.division.id as u16)).unwrap().to_string(),
+                id: r.division.id as u16,
                 standings: r
                     .team_records
                     .iter()
@@ -144,8 +220,21 @@ impl Division {
                     .collect(),
             })
             .collect();
-        // ensure display order is the same
-        s.sort_by(|a, b| a.id.cmp(&b.id));
+
+        if let Some(team) = favorite_team {
+            if let Some(order) = DIVISION_ORDERS.get(&team.division_id) {
+                s.sort_by_key(|standing| {
+                    order
+                        .iter()
+                        .position(|&x| x == standing.id)
+                        .unwrap_or(usize::MAX)
+                });
+            }
+        } else {
+            // ensure display order is the same
+            s.sort_by(|a, b| a.id.cmp(&b.id));
+        }
+
         s
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,5 +1,6 @@
 use crate::app::AppSettings;
-use crate::components::constants::TEAM_NAMES;
+use crate::components::constants::TEAM_IDS;
+use crate::components::standings::Team;
 use anyhow::Context;
 use chrono::{TimeZone, Utc};
 use chrono_tz::America::Los_Angeles;
@@ -62,10 +63,10 @@ impl ConfigFile {
         }
     }
 
-    fn validate_favorite_team(&self) -> Option<String> {
+    fn validate_favorite_team(&self) -> Option<Team> {
         if let Some(favorite) = &self.favorite_team {
-            if TEAM_NAMES.contains_key(favorite.as_str()) {
-                return Some(favorite.to_string());
+            if let Some(team) = TEAM_IDS.get(favorite.as_str()) {
+                return Some(*team);
             }
         }
         None

--- a/src/ui/schedule.rs
+++ b/src/ui/schedule.rs
@@ -1,13 +1,7 @@
 use crate::app::HomeOrAway;
 use crate::components::schedule::{ScheduleRow, ScheduleState};
-
-use tui::{
-    buffer::Buffer,
-    layout::{Constraint, Rect},
-    style::{Color, Modifier, Style},
-    text::Span,
-    widgets::{Block, BorderType, Borders, Cell, Row, StatefulWidget, Table},
-};
+use tui::prelude::*;
+use tui::widgets::{Block, BorderType, Borders, Cell, Padding, Row, Table};
 
 const HEADER: &[&str; 6] = &["away", "", "home", "", "time", "status"];
 
@@ -81,13 +75,13 @@ impl StatefulWidget for ScheduleWidget {
                 Block::default()
                     .borders(Borders::ALL)
                     .border_type(BorderType::Rounded)
+                    .padding(Padding::new(1, 1, 0, 0))
                     .title(Span::styled(
                         state.date_selector.format_date_border_title(),
                         Style::default().fg(Color::Black).bg(Color::Blue),
                     )),
             )
-            .row_highlight_style(selected_style)
-            .highlight_symbol(">> ");
+            .row_highlight_style(selected_style);
 
         StatefulWidget::render(t, area, buf, &mut state.state);
     }

--- a/src/ui/standings.rs
+++ b/src/ui/standings.rs
@@ -1,12 +1,6 @@
 use crate::components::standings::StandingsState;
-
-use tui::prelude::Span;
-use tui::{
-    buffer::Buffer,
-    layout::{Constraint, Rect},
-    style::{Color, Modifier, Style},
-    widgets::{Block, BorderType, Borders, Cell, Row, StatefulWidget, Table},
-};
+use tui::prelude::*;
+use tui::widgets::{Block, BorderType, Borders, Cell, Padding, Row, Table};
 
 const HEADER: &[&str; 7] = &["Team", "W", "L", "PCT", "GB", "WCGB", "STRK"];
 
@@ -21,7 +15,7 @@ impl StatefulWidget for StandingsWidget {
             .height(1)
             .style(Style::default().add_modifier(Modifier::BOLD | Modifier::UNDERLINED));
 
-        let mut rows = Vec::new();
+        let mut rows = Vec::with_capacity(36); // 30 teams + 6 divisions
         for d in &state.standings {
             // create a row for the division name
             let division = Row::new(vec![d.name.clone()])
@@ -36,7 +30,7 @@ impl StatefulWidget for StandingsWidget {
 
         let selected_style = Style::default().bg(Color::Blue).fg(Color::Black);
         let widths = [
-            Constraint::Length(20),
+            Constraint::Length(25),
             Constraint::Length(5),
             Constraint::Length(5),
             Constraint::Length(5),
@@ -50,13 +44,13 @@ impl StatefulWidget for StandingsWidget {
                 Block::default()
                     .borders(Borders::ALL)
                     .border_type(BorderType::Rounded)
+                    .padding(Padding::new(1, 1, 0, 0))
                     .title(Span::styled(
                         state.date_selector.format_date_border_title(),
                         Style::default().fg(Color::Black).bg(Color::Blue),
                     )),
             )
-            .row_highlight_style(selected_style)
-            .highlight_symbol(">> ");
+            .row_highlight_style(selected_style);
 
         StatefulWidget::render(t, area, buf, &mut state.state);
     }

--- a/src/ui/stats.rs
+++ b/src/ui/stats.rs
@@ -1,18 +1,9 @@
-use mlb_api::client::StatGroup;
-
 use crate::components::stats::{
     STATS_DEFAULT_COL_WIDTH, STATS_FIRST_COL_WIDTH, StatsState, TeamOrPlayer,
 };
-
-use tui::{
-    buffer::Buffer,
-    layout::{Alignment, Constraint, Direction, Layout, Rect},
-    style::{Color, Modifier, Style},
-    text::{Line, Span},
-    widgets::{
-        Block, BorderType, Borders, Cell, Paragraph, Row, StatefulWidget, Table, Widget, Wrap,
-    },
-};
+use mlb_api::client::StatGroup;
+use tui::prelude::*;
+use tui::widgets::{Block, BorderType, Borders, Cell, Padding, Paragraph, Row, Table, Wrap};
 
 pub const STATS_OPTIONS_WIDTH: u16 = 36;
 
@@ -92,6 +83,7 @@ impl StatefulWidget for StatsWidget {
                 Block::default()
                     .borders(Borders::ALL)
                     .border_type(BorderType::Rounded)
+                    .padding(Padding::new(1, 1, 0, 0))
                     .title(Span::styled(
                         state.date_selector.format_date_border_title(),
                         Style::default().fg(Color::Black).bg(Color::Blue),
@@ -149,6 +141,7 @@ impl StatefulWidget for StatsWidget {
                 .column_spacing(0)
                 .block(
                     Block::default()
+                        .padding(Padding::new(1, 1, 0, 0))
                         .borders(Borders::ALL)
                         .border_type(BorderType::Rounded),
                 )


### PR DESCRIPTION
- Improve the UI in Standings by sorting the results so the division with the favorite team is first. Also the favorite team is automatically selected, making it easy to find.
- Some general UI cleanup to make the tabs more consistent

Notes:
- standing sorting doesn't work well when there are 4 divisions (pre 1994 season)
- standings are totally broken pre divisional era (1968 and below)