### PR TITLE
Add win probability API and graphs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1069,7 +1069,7 @@ dependencies = [
 
 [[package]]
 name = "mlb-api"
-version = "0.0.14"
+version = "0.0.14-alpha.1"
 dependencies = [
  "chrono",
  "derive_builder",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1069,7 +1069,7 @@ dependencies = [
 
 [[package]]
 name = "mlb-api"
-version = "0.0.14-alpha.2"
+version = "0.0.15"
 dependencies = [
  "chrono",
  "derive_builder",
@@ -1082,7 +1082,7 @@ dependencies = [
 
 [[package]]
 name = "mlbt"
-version = "0.0.16-alpha.2"
+version = "0.0.16-alpha.3"
 dependencies = [
  "anyhow",
  "better-panic",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1069,7 +1069,7 @@ dependencies = [
 
 [[package]]
 name = "mlb-api"
-version = "0.0.14-alpha.1"
+version = "0.0.14-alpha.2"
 dependencies = [
  "chrono",
  "derive_builder",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ chrono-tz = { version = "0.10.3", features = ["serde"] }
 crossterm = "0.29.0"
 directories = "6.0.0"
 indexmap = "2.9.0"
-mlb-api = { path = "api", version = "0.0.14" }
+mlb-api = { path = "api", version = "0.0.14-alpha.1" }
 serde = { version = "1.0.219", features = ["derive"] }
 tokio = { version = "1.45.1", features = ["full"] }
 toml = "0.8.22"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mlbt"
-version = "0.0.16-alpha.2"
+version = "0.0.16-alpha.3"
 authors = ["Andrew Schneider <andjschneider@gmail.com>"]
 edition = "2024"
 license = "MIT"
@@ -27,7 +27,7 @@ chrono-tz = { version = "0.10.3", features = ["serde"] }
 crossterm = "0.29.0"
 directories = "6.0.0"
 indexmap = "2.9.0"
-mlb-api = { path = "api", version = "0.0.14-alpha.2" }
+mlb-api = { path = "api", version = "0.0.15" }
 serde = { version = "1.0.219", features = ["derive"] }
 tokio = { version = "1.45.1", features = ["full"] }
 toml = "0.8.22"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ chrono-tz = { version = "0.10.3", features = ["serde"] }
 crossterm = "0.29.0"
 directories = "6.0.0"
 indexmap = "2.9.0"
-mlb-api = { path = "api", version = "0.0.14-alpha.1" }
+mlb-api = { path = "api", version = "0.0.14-alpha.2" }
 serde = { version = "1.0.219", features = ["derive"] }
 tokio = { version = "1.45.1", features = ["full"] }
 toml = "0.8.22"

--- a/api/Cargo.toml
+++ b/api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mlb-api"
-version = "0.0.14"
+version = "0.0.14-alpha.1"
 authors = ["Andrew Schneider <andjschneider@gmail.com>"]
 edition = "2024"
 

--- a/api/Cargo.toml
+++ b/api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mlb-api"
-version = "0.0.14-alpha.1"
+version = "0.0.14-alpha.2"
 authors = ["Andrew Schneider <andjschneider@gmail.com>"]
 edition = "2024"
 

--- a/api/Cargo.toml
+++ b/api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mlb-api"
-version = "0.0.14-alpha.2"
+version = "0.0.15"
 authors = ["Andrew Schneider <andjschneider@gmail.com>"]
 edition = "2024"
 

--- a/api/src/client.rs
+++ b/api/src/client.rs
@@ -4,6 +4,7 @@ use crate::live::LiveResponse;
 use crate::schedule::ScheduleResponse;
 use crate::standings::StandingsResponse;
 use crate::stats::StatsResponse;
+use crate::win_probability::WinProbabilityResponse;
 
 use chrono::{DateTime, Datelike, Local, NaiveDate};
 use derive_builder::Builder;
@@ -85,6 +86,17 @@ impl MLBApi {
         }
         let url = format!(
             "{}v1.1/game/{}/feed/live?language=en",
+            self.base_url, game_id
+        );
+        self.get(url).await
+    }
+
+    pub async fn get_win_probability(&self, game_id: u64) -> WinProbabilityResponse {
+        if game_id == 0 {
+            return WinProbabilityResponse::default();
+        }
+        let url = format!(
+            "{}v1/game/{}/winProbability?fields=homeTeamWinProbability&fields=awayTeamWinProbability&fields=homeTeamWinProbabilityAdded&fields=atBatIndex&fields=about&fields=inning&fields=isTopInning&fields=captivatingIndex&fields=leverageIndex",
             self.base_url, game_id
         );
         self.get(url).await

--- a/api/src/lib.rs
+++ b/api/src/lib.rs
@@ -5,3 +5,4 @@ pub mod plays;
 pub mod schedule;
 pub mod standings;
 pub mod stats;
+pub mod win_probability;

--- a/api/src/win_probability.rs
+++ b/api/src/win_probability.rs
@@ -9,7 +9,7 @@ pub struct WinProbabilityResponse {
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct About {
-    pub at_bat_index: u16,
+    pub at_bat_index: u8,
     pub is_top_inning: bool,
     pub inning: u8,
     pub captivating_index: u8,
@@ -23,5 +23,5 @@ pub struct WinProbabilityPerAtBat {
     pub away_team_win_probability: f32,
     pub home_team_win_probability_added: f32,
     pub leverage_index: Option<f32>,
-    pub at_bat_index: u16,
+    pub at_bat_index: u8,
 }

--- a/api/src/win_probability.rs
+++ b/api/src/win_probability.rs
@@ -1,0 +1,27 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Default, Debug, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct WinProbabilityResponse {
+    pub at_bats: Vec<WinProbabilityPerAtBat>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct About {
+    pub at_bat_index: u16,
+    pub is_top_inning: bool,
+    pub inning: u8,
+    pub captivating_index: u8,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct WinProbabilityPerAtBat {
+    pub about: About,
+    pub home_team_win_probability: f32,
+    pub away_team_win_probability: f32,
+    pub home_team_win_probability_added: f32,
+    pub leverage_index: Option<f32>,
+    pub at_bat_index: u16,
+}

--- a/src/app.rs
+++ b/src/app.rs
@@ -3,6 +3,7 @@ use crate::state::app_state::AppState;
 use chrono::{ParseError, Utc};
 use mlb_api::live::LiveResponse;
 use mlb_api::schedule::ScheduleResponse;
+use mlb_api::win_probability::WinProbabilityResponse;
 
 #[derive(Copy, Clone, Debug, Default, PartialEq)]
 pub enum MenuItem {
@@ -70,11 +71,15 @@ impl App {
         }
     }
 
-    pub fn update_live_data(&mut self, live_data: &LiveResponse) {
+    pub fn update_live_data(
+        &mut self,
+        live_data: &LiveResponse,
+        win_probability: &WinProbabilityResponse,
+    ) {
         // only update gameday if the selected game is the same as the game being updated
         // this prevents gameday from showing incorrect data if the user scrolls through games quickly
         if Some(live_data.game_pk) == self.state.schedule.get_selected_game_opt() {
-            self.state.gameday.game.update(live_data);
+            self.state.gameday.game.update(live_data, win_probability);
         }
     }
 

--- a/src/components/debug.rs
+++ b/src/components/debug.rs
@@ -1,4 +1,5 @@
 use crate::app::App;
+use crate::components::game::win_probability::WinProbabilityAtBat;
 use std::fmt;
 use tui::Frame;
 
@@ -7,17 +8,21 @@ pub struct DebugInfo {
     pub gameday_url: String,
     pub terminal_width: u16,
     pub terminal_height: u16,
+    pub win_probability: WinProbabilityAtBat,
+    pub selected_at_bat: Option<u8>,
 }
 
 impl fmt::Display for DebugInfo {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(
             f,
-            "game id: {}, gameday: {}\nterminal height: {} width: {}\n",
+            "game id: {}, gameday: {}\nterminal height: {} width: {}\n{:?}\n{:?}",
             self.game_id.unwrap_or_default(),
             self.gameday_url,
             self.terminal_height,
             self.terminal_width,
+            self.win_probability,
+            self.selected_at_bat,
         )
     }
 }
@@ -29,6 +34,8 @@ impl DebugInfo {
             gameday_url: "https://www.mlb.com/scores".to_string(),
             terminal_width: 0,
             terminal_height: 0,
+            win_probability: WinProbabilityAtBat::default(),
+            selected_at_bat: None,
         }
     }
     // TODO add more info
@@ -42,5 +49,15 @@ impl DebugInfo {
         );
         self.terminal_width = f.area().width;
         self.terminal_height = f.area().height;
+        self.win_probability = app
+            .state
+            .gameday
+            .game
+            .win_probability
+            .at_bats
+            .get(&app.state.gameday.selected_at_bat().unwrap_or_default())
+            .cloned()
+            .unwrap_or_default();
+        self.selected_at_bat = app.state.gameday.selected_at_bat();
     }
 }

--- a/src/components/game/matchup.rs
+++ b/src/components/game/matchup.rs
@@ -192,6 +192,7 @@ impl Matchup {
             vec![self.away_name.clone(), self.away_score.to_string()],
             vec![self.home_name.clone(), self.home_score.to_string()],
             vec!["inning".to_string(), self.inning.clone()],
+            // vec!["ab #".to_string(), self.ab_index.to_string()],
             vec!["outs".to_string(), self.count.outs.to_string()],
             vec!["balls".to_string(), self.count.balls.to_string()],
             vec!["strikes".to_string(), self.count.strikes.to_string()],

--- a/src/components/game/matchup.rs
+++ b/src/components/game/matchup.rs
@@ -1,22 +1,33 @@
 use mlb_api::live::LiveResponse;
 use mlb_api::plays::{Count, Play};
 
+use crate::components::constants::TEAM_IDS;
+use crate::components::standings::Team;
 use std::fmt;
 
 const DEFAULT_NAME: &str = "-";
 
 pub struct Summary {
-    pub home_name: String,
-    pub away_name: String,
+    pub home_team: Team,
+    pub away_team: Team,
     pub on_deck: String,
     pub in_hole: String,
 }
 
 impl Default for Summary {
     fn default() -> Self {
+        let home_team = Team {
+            abbreviation: "H",
+            ..Team::default()
+        };
+        let away_team = Team {
+            abbreviation: "A",
+            ..Team::default()
+        };
+
         Self {
-            home_name: DEFAULT_NAME.to_owned(),
-            away_name: DEFAULT_NAME.to_owned(),
+            home_team,
+            away_team,
             on_deck: DEFAULT_NAME.to_owned(),
             in_hole: DEFAULT_NAME.to_owned(),
         }
@@ -36,8 +47,14 @@ impl From<&LiveResponse> for Summary {
         };
 
         Self {
-            home_name: live_game.game_data.teams.home.team_name.clone(),
-            away_name: live_game.game_data.teams.away.team_name.clone(),
+            home_team: TEAM_IDS
+                .get(live_game.game_data.teams.home.name.as_str())
+                .cloned()
+                .unwrap_or_default(),
+            away_team: TEAM_IDS
+                .get(live_game.game_data.teams.away.name.as_str())
+                .cloned()
+                .unwrap_or_default(),
             on_deck,
             in_hole,
         }
@@ -171,9 +188,9 @@ impl Matchup {
             ("".to_string(), "".to_string())
         };
         Self {
-            home_name: summary.home_name.clone(),
+            home_name: summary.home_team.team_name.to_string(),
             home_score: matchup.home_score,
-            away_name: summary.away_name.clone(),
+            away_name: summary.away_team.team_name.to_string(),
             away_score: matchup.away_score,
             inning: matchup.inning.clone(),
             pitcher_name: matchup.pitcher_name.clone(),
@@ -192,7 +209,6 @@ impl Matchup {
             vec![self.away_name.clone(), self.away_score.to_string()],
             vec![self.home_name.clone(), self.home_score.to_string()],
             vec!["inning".to_string(), self.inning.clone()],
-            // vec!["ab #".to_string(), self.ab_index.to_string()],
             vec!["outs".to_string(), self.count.outs.to_string()],
             vec!["balls".to_string(), self.count.balls.to_string()],
             vec!["strikes".to_string(), self.count.strikes.to_string()],

--- a/src/components/game/mod.rs
+++ b/src/components/game/mod.rs
@@ -5,3 +5,4 @@ pub mod pitch_event;
 pub mod pitches;
 pub mod plays;
 pub mod strikezone;
+pub mod win_probability;

--- a/src/components/game/win_probability.rs
+++ b/src/components/game/win_probability.rs
@@ -1,0 +1,69 @@
+use crate::components::game::live_game::AtBatIndex;
+use indexmap::IndexMap;
+use mlb_api::win_probability::{WinProbabilityPerAtBat, WinProbabilityResponse};
+
+#[derive(Debug)]
+pub struct WinProbability {
+    pub at_bats: IndexMap<AtBatIndex, WinProbabilityAtBat>,
+}
+
+#[derive(Debug, Clone, Copy)]
+#[allow(dead_code)]
+pub struct WinProbabilityAtBat {
+    pub at_bat_index: AtBatIndex,
+    pub is_top_inning: bool,
+    pub inning: u8,
+    pub home_team_wp: f32,
+    pub away_team_wp: f32,
+    pub home_team_wp_added: f32,
+    pub leverage_index: f32,
+}
+
+impl Default for WinProbability {
+    fn default() -> Self {
+        Self {
+            at_bats: IndexMap::from([(0, WinProbabilityAtBat::default())]),
+        }
+    }
+}
+
+impl Default for WinProbabilityAtBat {
+    fn default() -> Self {
+        WinProbabilityAtBat {
+            at_bat_index: 0,
+            is_top_inning: true,
+            inning: 1,
+            home_team_wp: 50.0,
+            away_team_wp: 50.0,
+            home_team_wp_added: 0.0,
+            leverage_index: 0.0,
+        }
+    }
+}
+
+impl From<&WinProbabilityPerAtBat> for WinProbabilityAtBat {
+    fn from(at_bat: &WinProbabilityPerAtBat) -> Self {
+        WinProbabilityAtBat {
+            at_bat_index: at_bat.at_bat_index,
+            is_top_inning: at_bat.about.is_top_inning,
+            inning: at_bat.about.inning,
+            home_team_wp: at_bat.home_team_win_probability,
+            away_team_wp: at_bat.away_team_win_probability,
+            home_team_wp_added: at_bat.home_team_win_probability_added,
+            leverage_index: at_bat.leverage_index.unwrap_or(0.0),
+        }
+    }
+}
+
+impl From<&WinProbabilityResponse> for WinProbability {
+    fn from(response: &WinProbabilityResponse) -> Self {
+        let mut at_bats = IndexMap::new();
+        for ab in &response.at_bats {
+            at_bats.insert(ab.at_bat_index, WinProbabilityAtBat::from(ab));
+        }
+        if at_bats.is_empty() {
+            at_bats.insert(0, WinProbabilityAtBat::default());
+        }
+        WinProbability { at_bats }
+    }
+}

--- a/src/components/schedule.rs
+++ b/src/components/schedule.rs
@@ -10,12 +10,22 @@ use std::cmp::Ordering;
 use tui::widgets::TableState;
 
 /// ScheduleState is used to render the schedule as a `tui-rs` table.
-#[derive(Default)]
 pub struct ScheduleState {
     pub state: TableState,
     pub schedule: Vec<ScheduleRow>,
     pub date_selector: DateSelector,
     pub show_win_probability: bool,
+}
+
+impl Default for ScheduleState {
+    fn default() -> Self {
+        ScheduleState {
+            state: TableState::default(),
+            schedule: Vec::new(),
+            date_selector: DateSelector::default(),
+            show_win_probability: true,
+        }
+    }
 }
 
 /// The information needed to create a single row in a table.

--- a/src/components/schedule.rs
+++ b/src/components/schedule.rs
@@ -15,6 +15,7 @@ pub struct ScheduleState {
     pub state: TableState,
     pub schedule: Vec<ScheduleRow>,
     pub date_selector: DateSelector,
+    pub show_win_probability: bool,
 }
 
 /// The information needed to create a single row in a table.
@@ -73,6 +74,10 @@ impl ScheduleState {
     pub fn get_selected_game_opt(&self) -> Option<u64> {
         let idx = self.state.selected()?;
         self.schedule.get(idx).map(|s| s.game_id)
+    }
+
+    pub fn toggle_win_probability(&mut self) {
+        self.show_win_probability = !self.show_win_probability;
     }
 
     pub fn next(&mut self) {

--- a/src/components/standings.rs
+++ b/src/components/standings.rs
@@ -38,6 +38,18 @@ pub struct Team {
     pub abbreviation: &'static str,
 }
 
+impl Default for Team {
+    fn default() -> Self {
+        Self {
+            id: 0,
+            division_id: 0,
+            name: "unknown",
+            team_name: "unknown",
+            abbreviation: "UNK",
+        }
+    }
+}
+
 /// Standing information per team.
 #[derive(Debug, Default)]
 pub struct Standing {

--- a/src/draw.rs
+++ b/src/draw.rs
@@ -129,7 +129,6 @@ fn draw_scoreboard(f: &mut Frame, rect: Rect, app: &mut App) {
         ScheduleWidget {
             tz_abbreviation: app.settings.timezone_abbreviation.clone(),
         },
-        // don't use win_prob[0] so the border is full height
         chunks[0],
         &mut app.state.schedule,
     );
@@ -205,14 +204,19 @@ fn draw_standings(f: &mut Frame, rect: Rect, app: &mut App) {
 }
 
 fn draw_win_probability(f: &mut Frame, rect: Rect, app: &mut App) {
-    f.render_widget(
-        WinProbabilityWidget {
-            game: &app.state.gameday.game,
-            selected_at_bat: app.state.gameday.selected_at_bat(),
-            active_tab: MenuItem::Scoreboard,
-        },
-        rect,
-    );
+    // only render if it doesn't overlap the schedule
+    let minimum_size =
+        WinProbabilityWidget::get_min_table_height() + app.state.schedule.schedule.len() + 2; // +2 for borders 
+    if rect.height > minimum_size as u16 {
+        f.render_widget(
+            WinProbabilityWidget {
+                game: &app.state.gameday.game,
+                selected_at_bat: app.state.gameday.selected_at_bat(),
+                active_tab: MenuItem::Scoreboard,
+            },
+            rect,
+        );
+    }
 }
 
 fn draw_help(f: &mut Frame, rect: Rect) {

--- a/src/draw.rs
+++ b/src/draw.rs
@@ -134,11 +134,7 @@ fn draw_scoreboard(f: &mut Frame, rect: Rect, app: &mut App) {
         &mut app.state.schedule,
     );
     if app.state.schedule.show_win_probability {
-        let win_prob = Layout::default()
-            .direction(Direction::Vertical)
-            .constraints([Constraint::Percentage(80), Constraint::Percentage(20)].as_ref())
-            .split(chunks[0]);
-        draw_win_probability(f, win_prob[1], app);
+        draw_win_probability(f, chunks[0], app);
     }
 
     // display line score and box score on right
@@ -213,6 +209,7 @@ fn draw_win_probability(f: &mut Frame, rect: Rect, app: &mut App) {
         WinProbabilityWidget {
             game: &app.state.gameday.game,
             selected_at_bat: app.state.gameday.selected_at_bat(),
+            active_tab: MenuItem::Scoreboard,
         },
         rect,
     );

--- a/src/draw.rs
+++ b/src/draw.rs
@@ -11,6 +11,7 @@ use crate::state::network::LoadingState;
 use crate::ui::boxscore::TeamBatterBoxscoreWidget;
 use crate::ui::date_selector::DateSelectorWidget;
 use crate::ui::gameday::gameday_widget::GamedayWidget;
+use crate::ui::gameday::win_probability::WinProbabilityWidget;
 use crate::ui::help::{DOCS, HelpWidget};
 use crate::ui::layout::LayoutAreas;
 use crate::ui::linescore::LineScoreWidget;
@@ -128,9 +129,17 @@ fn draw_scoreboard(f: &mut Frame, rect: Rect, app: &mut App) {
         ScheduleWidget {
             tz_abbreviation: app.settings.timezone_abbreviation.clone(),
         },
+        // don't use win_prob[0] so the border is full height
         chunks[0],
         &mut app.state.schedule,
     );
+    if app.state.schedule.show_win_probability {
+        let win_prob = Layout::default()
+            .direction(Direction::Vertical)
+            .constraints([Constraint::Percentage(80), Constraint::Percentage(20)].as_ref())
+            .split(chunks[0]);
+        draw_win_probability(f, win_prob[1], app);
+    }
 
     // display line score and box score on right
     draw_border(f, chunks[1], Color::White);
@@ -197,6 +206,16 @@ fn draw_stats(f: &mut Frame, rect: Rect, app: &mut App) {
 
 fn draw_standings(f: &mut Frame, rect: Rect, app: &mut App) {
     f.render_stateful_widget(StandingsWidget {}, rect, &mut app.state.standings);
+}
+
+fn draw_win_probability(f: &mut Frame, rect: Rect, app: &mut App) {
+    f.render_widget(
+        WinProbabilityWidget {
+            game: &app.state.gameday.game,
+            selected_at_bat: app.state.gameday.selected_at_bat(),
+        },
+        rect,
+    );
 }
 
 fn draw_help(f: &mut Frame, rect: Rect) {

--- a/src/keys.rs
+++ b/src/keys.rs
@@ -57,6 +57,7 @@ pub async fn handle_key_bindings(
             load_game_data(guard, network_requests).await;
         }
         (MenuItem::Scoreboard, Char(':')) => guard.update_tab(MenuItem::DatePicker),
+        (MenuItem::Scoreboard, Char('w')) => guard.state.schedule.toggle_win_probability(),
         (MenuItem::Scoreboard, KeyCode::Enter) => {
             guard.update_tab(MenuItem::Gameday);
             load_game_data(guard, network_requests).await;
@@ -121,6 +122,7 @@ pub async fn handle_key_bindings(
         (MenuItem::Gameday, Char('i')) => guard.state.gameday.toggle_info(),
         (MenuItem::Gameday, Char('p')) => guard.state.gameday.toggle_at_bat(),
         (MenuItem::Gameday, Char('b')) => guard.state.gameday.toggle_boxscore(),
+        (MenuItem::Gameday, Char('w')) => guard.state.gameday.toggle_win_probability(),
         (MenuItem::Gameday, Char('j')) => guard.state.gameday.previous_at_bat(),
         (MenuItem::Gameday, Char('k')) => guard.state.gameday.next_at_bat(),
         (MenuItem::Gameday, Char('l')) => guard.state.gameday.live(),

--- a/src/keys.rs
+++ b/src/keys.rs
@@ -173,11 +173,18 @@ async fn load_standings(guard: AppGuard<'_>, network_requests: &mpsc::Sender<Net
 
 async fn load_scoreboard(guard: AppGuard<'_>, network_requests: &mpsc::Sender<NetworkRequest>) {
     let date = guard.state.schedule.date_selector.date;
+    let game_id = guard.state.schedule.get_selected_game_opt();
     drop(guard);
 
     let _ = network_requests
         .send(NetworkRequest::Schedule { date })
         .await;
+
+    if let Some(game_id) = game_id {
+        let _ = network_requests
+            .send(NetworkRequest::GameData { game_id })
+            .await;
+    }
 }
 
 async fn handle_date_change(guard: AppGuard<'_>, network_requests: &mpsc::Sender<NetworkRequest>) {

--- a/src/main.rs
+++ b/src/main.rs
@@ -136,9 +136,12 @@ async fn handle_network_response(
                     .await;
             }
         }
-        NetworkResponse::GameDataLoaded { game } => {
+        NetworkResponse::GameDataLoaded {
+            game,
+            win_probability,
+        } => {
             let mut guard = app.lock().await;
-            guard.update_live_data(&game);
+            guard.update_live_data(&game, &win_probability);
         }
         NetworkResponse::StandingsLoaded { standings } => {
             let mut guard = app.lock().await;

--- a/src/state/gameday.rs
+++ b/src/state/gameday.rs
@@ -74,6 +74,10 @@ impl GamedayState {
     pub fn toggle_boxscore(&mut self) {
         self.panels.boxscore = !self.panels.boxscore;
     }
+
+    pub fn toggle_win_probability(&mut self) {
+        self.panels.win_probability = !self.panels.win_probability;
+    }
 }
 
 /// Store which panels should be rendered in the Gameday tab.
@@ -82,6 +86,7 @@ pub struct GamedayPanels {
     pub info: bool,
     pub at_bat: bool,
     pub boxscore: bool,
+    pub win_probability: bool,
 }
 
 impl GamedayPanels {
@@ -97,6 +102,7 @@ impl Default for GamedayPanels {
             info: true,
             at_bat: true,
             boxscore: false,
+            win_probability: true,
         }
     }
 }

--- a/src/state/messages.rs
+++ b/src/state/messages.rs
@@ -6,6 +6,7 @@ use mlb_api::live::LiveResponse;
 use mlb_api::schedule::ScheduleResponse;
 use mlb_api::standings::StandingsResponse;
 use mlb_api::stats::StatsResponse;
+use mlb_api::win_probability::WinProbabilityResponse;
 
 #[derive(Debug, Clone)]
 pub enum NetworkRequest {
@@ -34,6 +35,7 @@ pub enum NetworkResponse {
     },
     GameDataLoaded {
         game: Box<LiveResponse>,
+        win_probability: WinProbabilityResponse,
     },
     StandingsLoaded {
         standings: StandingsResponse,

--- a/src/state/network.rs
+++ b/src/state/network.rs
@@ -72,9 +72,13 @@ impl NetworkWorker {
     }
 
     async fn handle_load_game_data(&self, game_id: u64) -> Option<NetworkResponse> {
-        let game = self.client.get_live_data(game_id).await;
+        let (game, wp) = tokio::join!(
+            self.client.get_live_data(game_id),
+            self.client.get_win_probability(game_id),
+        );
         Some(NetworkResponse::GameDataLoaded {
             game: Box::new(game),
+            win_probability: wp,
         })
     }
 

--- a/src/ui/gameday/gameday_widget.rs
+++ b/src/ui/gameday/gameday_widget.rs
@@ -1,3 +1,4 @@
+use crate::app::MenuItem;
 use crate::draw;
 use crate::state::app_state::HomeOrAway;
 use crate::state::gameday::GamedayState;
@@ -75,6 +76,7 @@ impl Widget for GamedayWidget<'_> {
                     WinProbabilityWidget {
                         game: &self.state.game,
                         selected_at_bat: self.state.selected_at_bat(),
+                        active_tab: MenuItem::Gameday,
                     },
                     chunks[1],
                     buf,

--- a/src/ui/gameday/gameday_widget.rs
+++ b/src/ui/gameday/gameday_widget.rs
@@ -5,9 +5,10 @@ use crate::ui::boxscore::TeamBatterBoxscoreWidget;
 use crate::ui::gameday::at_bat::AtBatWidget;
 use crate::ui::gameday::matchup::MatchupWidget;
 use crate::ui::gameday::plays::InningPlaysWidget;
+use crate::ui::gameday::win_probability::WinProbabilityWidget;
 use crate::ui::layout::LayoutAreas;
 use crate::ui::linescore::LineScoreWidget;
-use tui::prelude::{Buffer, Color, Rect, Widget};
+use tui::prelude::{Buffer, Color, Constraint, Direction, Layout, Rect, Widget};
 
 pub struct GamedayWidget<'a> {
     pub state: &'a GamedayState,
@@ -62,7 +63,25 @@ impl Widget for GamedayWidget<'_> {
                 game: &self.state.game,
                 selected_at_bat: self.state.selected_at_bat(),
             };
-            Widget::render(innings_widget, p, buf);
+
+            if self.state.panels.win_probability {
+                let chunks = Layout::default()
+                    .direction(Direction::Vertical)
+                    .constraints([Constraint::Percentage(80), Constraint::Percentage(20)].as_ref())
+                    .split(p);
+                Widget::render(innings_widget, chunks[0], buf);
+
+                Widget::render(
+                    WinProbabilityWidget {
+                        game: &self.state.game,
+                        selected_at_bat: self.state.selected_at_bat(),
+                    },
+                    chunks[1],
+                    buf,
+                );
+            } else {
+                Widget::render(innings_widget, p, buf);
+            }
         }
     }
 }

--- a/src/ui/gameday/gameday_widget.rs
+++ b/src/ui/gameday/gameday_widget.rs
@@ -68,10 +68,10 @@ impl Widget for GamedayWidget<'_> {
             if self.state.panels.win_probability {
                 let chunks = Layout::default()
                     .direction(Direction::Vertical)
-                    .constraints([Constraint::Percentage(80), Constraint::Percentage(20)].as_ref())
+                    .constraints([Constraint::Fill(1), Constraint::Percentage(20)].as_ref())
                     .split(p);
-                Widget::render(innings_widget, chunks[0], buf);
 
+                Widget::render(innings_widget, chunks[0], buf);
                 Widget::render(
                     WinProbabilityWidget {
                         game: &self.state.game,

--- a/src/ui/gameday/mod.rs
+++ b/src/ui/gameday/mod.rs
@@ -2,3 +2,4 @@ pub(crate) mod at_bat;
 pub(crate) mod gameday_widget;
 pub(crate) mod matchup;
 pub(crate) mod plays;
+pub(crate) mod win_probability;

--- a/src/ui/gameday/plays.rs
+++ b/src/ui/gameday/plays.rs
@@ -5,11 +5,30 @@ use std::vec;
 use tui::prelude::*;
 use tui::widgets::{Paragraph, Wrap};
 
+// These colors match the red, green, and blue used in the pitch data from the API.
+pub const RED: Color = Color::Rgb(170, 21, 11);
+pub const GREEN: Color = Color::Rgb(39, 161, 39);
 // This matches the blue used in the pitch data from the API. It's used for contact (hit, out, run
 // scoring).
 pub const BLUE: Color = Color::Rgb(26, 86, 190);
 pub const SCORING_SYMBOL: char = '!';
 pub const SELECTION_SYMBOL: char = '>';
+
+pub struct InningPlaysWidget<'a> {
+    pub game: &'a GameStateV2,
+    pub selected_at_bat: Option<u8>,
+}
+
+impl Widget for InningPlaysWidget<'_> {
+    fn render(self, area: Rect, buf: &mut Buffer) {
+        let chunks = LayoutAreas::for_info(area);
+
+        let inning_plays = format_plays(self.game, self.selected_at_bat);
+        let paragraph = Paragraph::new(inning_plays).wrap(Wrap { trim: false });
+
+        Widget::render(paragraph, chunks[1], buf);
+    }
+}
 
 /// Format the plays for the current half inning as TUI Lines.
 fn format_plays(game: &GameStateV2, selected_at_bat: Option<u8>) -> Vec<Line> {
@@ -90,21 +109,5 @@ fn format_outs(play: &PlayResult) -> Span {
         Span::raw(format!(" {} {}", &play.count.outs, out))
     } else {
         Span::raw("")
-    }
-}
-
-pub struct InningPlaysWidget<'a> {
-    pub game: &'a GameStateV2,
-    pub selected_at_bat: Option<u8>,
-}
-
-impl Widget for InningPlaysWidget<'_> {
-    fn render(self, area: Rect, buf: &mut Buffer) {
-        let chunks = LayoutAreas::for_info(area);
-
-        let inning_plays = format_plays(self.game, self.selected_at_bat);
-        let paragraph = Paragraph::new(inning_plays).wrap(Wrap { trim: false });
-
-        Widget::render(paragraph, chunks[1], buf);
     }
 }

--- a/src/ui/gameday/win_probability.rs
+++ b/src/ui/gameday/win_probability.rs
@@ -24,13 +24,22 @@ struct WinProbabilityData<'a> {
     table_height: u16,
 }
 
+impl WinProbabilityWidget<'_> {
+    pub fn get_min_table_height() -> usize {
+        WinProbabilityData::MINIMUM_TABLE_HEIGHT
+    }
+}
+
 impl Widget for WinProbabilityWidget<'_> {
     fn render(self, area: Rect, buf: &mut Buffer) {
         match self.active_tab {
             MenuItem::Scoreboard => {
                 let chunks = Layout::default()
                     .direction(Direction::Vertical)
-                    .constraints([Constraint::Percentage(65), Constraint::Percentage(35)].as_ref())
+                    .constraints([
+                        Constraint::Fill(1),
+                        Constraint::Length(WinProbabilityData::MINIMUM_TABLE_HEIGHT as u16),
+                    ])
                     .horizontal_margin(2)
                     .vertical_margin(1)
                     .split(area);
@@ -41,7 +50,7 @@ impl Widget for WinProbabilityWidget<'_> {
             MenuItem::Gameday => {
                 let chunks = Layout::default()
                     .direction(Direction::Horizontal)
-                    .constraints([Constraint::Length(26), Constraint::Fill(1)].as_ref())
+                    .constraints([Constraint::Length(30), Constraint::Fill(1)].as_ref())
                     .horizontal_margin(2)
                     .vertical_margin(1)
                     .split(area);
@@ -57,6 +66,7 @@ impl Widget for WinProbabilityWidget<'_> {
 
 impl<'a> WinProbabilityData<'a> {
     const INTERPOLATION_TARGET_COUNT: usize = 50;
+    const MINIMUM_TABLE_HEIGHT: usize = 10;
 
     fn new(game: &'a GameStateV2, selected_at_bat_index: Option<u8>, table_height: u16) -> Self {
         Self {

--- a/src/ui/gameday/win_probability.rs
+++ b/src/ui/gameday/win_probability.rs
@@ -1,0 +1,214 @@
+use crate::components::game::live_game::GameStateV2;
+use crate::components::game::win_probability::WinProbabilityAtBat;
+use crate::ui::gameday::plays::{BLUE, GREEN, RED};
+use indexmap::IndexMap;
+use tui::prelude::*;
+use tui::widgets::{Bar, BarChart, BarGroup, Cell, Row, Table};
+
+pub struct WinProbabilityWidget<'a> {
+    pub game: &'a GameStateV2,
+    pub selected_at_bat: Option<u8>,
+}
+
+struct WinProbabilityData<'a> {
+    at_bats: &'a IndexMap<u8, WinProbabilityAtBat>,
+    selected_at_bat_index: Option<u8>,
+    table_height: u16,
+}
+
+impl Widget for WinProbabilityWidget<'_> {
+    fn render(self, area: Rect, buf: &mut Buffer) {
+        let chunks = Layout::default()
+            .direction(Direction::Horizontal)
+            .constraints([Constraint::Length(26), Constraint::Fill(1)].as_ref())
+            .horizontal_margin(2)
+            .vertical_margin(1)
+            .split(area);
+
+        let data = WinProbabilityData::new(self.game, self.selected_at_bat, chunks[0].height);
+
+        data.render_table(chunks[0], buf);
+        data.render_chart(chunks[1], buf);
+    }
+}
+
+impl<'a> WinProbabilityData<'a> {
+    fn new(game: &'a GameStateV2, selected_at_bat_index: Option<u8>, table_height: u16) -> Self {
+        Self {
+            at_bats: &game.win_probability.at_bats,
+            selected_at_bat_index,
+            table_height,
+        }
+    }
+
+    fn create_table_row(&self, at_bat: &WinProbabilityAtBat) -> Row {
+        let label = match at_bat.is_top_inning {
+            true => format!("top {}", at_bat.inning),
+            false => format!("bot {}", at_bat.inning),
+        };
+
+        let home_wp = at_bat.home_team_wp.clamp(0.0, 100.0);
+        let wp = if home_wp == 100.0 || home_wp == 0.0 {
+            format!("{:.0}%", home_wp) // just show 100% or 0%
+        } else {
+            format!("{:.1}%", home_wp)
+        };
+
+        let wp_color = match home_wp {
+            99.0..=100.0 => BLUE,
+            45.0..=55.0 => GREEN,
+            0.0..=0.99 => Color::Red,
+            _ => Color::White,
+        };
+
+        let leverage = at_bat.leverage_index;
+        let li = if leverage == 0.0 {
+            "0".to_string() // don't show "0.00", just "0"
+        } else {
+            format!("{:.2}", leverage)
+        };
+        let leverage_color = if leverage > 2.0 { RED } else { Color::White };
+
+        let wpa = if at_bat.home_team_wp_added <= -10.0 {
+            format!("{:4.1}", at_bat.home_team_wp_added)
+        } else {
+            // add space to align with `-` sign
+            format!(" {:4.1}", at_bat.home_team_wp_added)
+        };
+
+        Row::new([
+            Cell::from(format!("{:<8}", label)),
+            Cell::from(format!(" {:<4}", li)).style(Style::default().fg(leverage_color)),
+            Cell::from(wpa),
+            Cell::from(format!("{:<6}", wp)).style(Style::default().fg(wp_color)),
+        ])
+    }
+
+    fn render_table(&self, area: Rect, buf: &mut Buffer) {
+        let header = Row::new([
+            Cell::from(format!("{:<8}", "inning")),
+            Cell::from(format!(" {:<4}", "li")),
+            Cell::from(format!("{:^5}", "wpa")),
+            Cell::from(format!("{:<6}", "win")),
+        ])
+        .style(Style::default().add_modifier(Modifier::BOLD | Modifier::UNDERLINED));
+
+        let (start_idx, end_idx, selected_row_index) = self.calculate_visible_range();
+
+        let visible_rows: Vec<Row> = self
+            .at_bats
+            .values()
+            .rev() // newest first
+            .skip(start_idx)
+            .take(end_idx - start_idx)
+            .map(|at_bat| self.create_table_row(at_bat))
+            .collect();
+
+        let mut table_state = tui::widgets::TableState::default();
+        table_state.select(selected_row_index);
+
+        let table = Table::new(
+            visible_rows,
+            [
+                Constraint::Min(8), // inning
+                Constraint::Min(5), // leverage index
+                Constraint::Min(7), // wpa
+                Constraint::Min(6), // win %
+            ],
+        )
+        .style(Style::default().fg(Color::White))
+        .row_highlight_style(Style::default().bg(BLUE).add_modifier(Modifier::BOLD))
+        .header(header);
+
+        StatefulWidget::render(table, area, buf, &mut table_state);
+    }
+
+    fn create_chart_bar(&self, at_bat: &WinProbabilityAtBat) -> Bar {
+        let home_wp = (at_bat.home_team_wp.round() as u8).clamp(0, 100);
+        Bar::default()
+            .value(home_wp.into())
+            .text_value("".to_string())
+            .style(Style::default().fg(BLUE))
+    }
+
+    fn create_header_bar(&self, width: u16) -> Bar {
+        Bar::default()
+            .value(100)
+            // use the width of the the area to ensure underline goes all the way across
+            .text_value(format!("{: <1$}", "", width as usize))
+            .value_style(
+                Style::default()
+                    .fg(Color::Gray)
+                    .underlined()
+                    .underline_color(Color::White),
+            )
+            .style(Style::default().fg(Color::Black))
+    }
+
+    fn render_chart(&self, area: Rect, buf: &mut Buffer) {
+        let (start_idx, end_idx, _) = self.calculate_visible_range();
+
+        let bars: Vec<Bar> = self
+            .at_bats
+            .values()
+            .rev() // newest first
+            .skip(start_idx)
+            .take(end_idx - start_idx)
+            .map(|at_bat| self.create_chart_bar(at_bat))
+            .collect();
+
+        let mut all_bars = Vec::with_capacity(1 + bars.len());
+        // add header bar at the top
+        all_bars.push(self.create_header_bar(area.width));
+        all_bars.extend(bars);
+
+        let chart = BarChart::default()
+            .data(BarGroup::default().bars(&all_bars))
+            .direction(Direction::Horizontal)
+            .bar_width(1)
+            .bar_gap(0)
+            .value_style(Style::default().fg(BLUE).add_modifier(Modifier::BOLD))
+            .max(100);
+
+        Widget::render(chart, area, buf);
+    }
+
+    fn get_selected_position(&self) -> Option<usize> {
+        let selected_ab = self.selected_at_bat_index?;
+        // since IndexMap maintains order and at_bat_index is the key, we can use get_index_of
+        self.at_bats.get_index_of(&selected_ab)
+    }
+
+    /// Calculate the number of rows the should be visible for both the bar chart and the table.
+    fn calculate_visible_range(&self) -> (usize, usize, Option<usize>) {
+        let total_rows = self.at_bats.len();
+        let visible_count = self.table_height.saturating_sub(1) as usize; // -1 for header
+
+        if let Some(selected_pos) = self.get_selected_position() {
+            // reverse the position to display newest first
+            let reversed_pos = total_rows.saturating_sub(1).saturating_sub(selected_pos);
+
+            let scroll_offset = if reversed_pos == total_rows.saturating_sub(1) {
+                // if selecting the last item (newest), position it at the bottom
+                reversed_pos.saturating_sub(visible_count.saturating_sub(1))
+            } else if reversed_pos >= visible_count {
+                // otherwise, center it in the view
+                reversed_pos.saturating_sub(visible_count / 2)
+            } else {
+                0
+            };
+
+            // ensure we don't scroll past the end
+            let max_scroll = total_rows.saturating_sub(visible_count);
+            let scroll_offset = scroll_offset.min(max_scroll);
+            let end_idx = (scroll_offset + visible_count).min(total_rows);
+            let relative_selection = Some(reversed_pos.saturating_sub(scroll_offset));
+
+            (scroll_offset, end_idx, relative_selection)
+        } else {
+            // no selection, show from start (newest)
+            let end_idx = visible_count.min(total_rows);
+            (0, end_idx, None)
+        }
+    }
+}

--- a/src/ui/help.rs
+++ b/src/ui/help.rs
@@ -9,7 +9,7 @@ use crate::components::banner::BANNER;
 use crate::config::ConfigFile;
 
 const HEADER: &[&str; 2] = &["Description", "Key"];
-pub const DOCS: &[&[&str; 2]; 31] = &[
+pub const DOCS: &[&[&str; 2]; 33] = &[
     &["Exit help", "Esc"],
     &["Quit", "q"],
     &["Full screen", "f"],
@@ -18,11 +18,13 @@ pub const DOCS: &[&[&str; 2]; 31] = &[
     &["Move up", "k"],
     &["Select date", ":"],
     &["Switch boxscore team", "h/a"],
+    &["Toggle win probability", "w"],
     &["Gameday", "2"],
     &["Toggle game info", "i"],
     &["Toggle pitches", "p"],
     &["Toggle boxscore", "b"],
     &["Switch boxscore team", "h/a"],
+    &["Toggle win probability", "w"],
     &["Move down at bat", "j"],
     &["Move up at bat", "k"],
     &["Go to live at bat", "l"],

--- a/src/ui/layout.rs
+++ b/src/ui/layout.rs
@@ -81,7 +81,7 @@ impl LayoutAreas {
             .vertical_margin(1)
             .constraints(
                 [
-                    Constraint::Length(13),      // game info
+                    Constraint::Length(14),      // game info
                     Constraint::Percentage(100), // inning plays
                 ]
                 .as_ref(),


### PR DESCRIPTION
This adds a win probability endpoint from the stats API and graphs in the Schedule and Gameday views.

- In the Schedule tab, the whole game win probability is shown so you can get a quick overview of the flow of the game. This is heavily inspired by Baseball Savant's win probability graph.
<img width="608" alt="image" src="https://github.com/user-attachments/assets/6ef3e473-9640-4b43-99cc-1c482a968a52" />

- In the Gameday tab, the last few at bats are shown with more stats around the win probability for that specific at bat. The at bat selection scrolls with the plays, which lets you see how impactful specific at bats were to the win probability. The info is:
  - leverage index (li)
  - win probability added (wpa)
  - home team win probability (win)

<img width="634" alt="Screenshot 2025-06-14 at 10 30 10 AM" src="https://github.com/user-attachments/assets/e8dca979-e2cc-48b3-9fca-788289482538" />

