### PR TITLE
Add team record to schedule UI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- The schedule view now displays the team record and the losing team is 
+  completely greyed out. [PR 62](https://github.com/mlb-rs/mlbt/pull/62)
 - Standings are now sorted by the configured favorite team, so the division with
   the team is always shown first. Additionally, the favorite team is 
   automatically selected and highlighted. [PR 58](https://github.com/mlb-rs/mlbt/pull/58)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- The schedule view now displays the team record and the losing team is 
+- The Schedule view now displays the team record and the losing team is 
   completely greyed out. [PR 62](https://github.com/mlb-rs/mlbt/pull/62)
 - Standings are now sorted by the configured favorite team, so the division with
   the team is always shown first. Additionally, the favorite team is 
@@ -18,7 +18,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Add win probability API and graphs. Get an overview of the win probability of
-  a game in the Schedule view and a more detailed breakdown in Gameday view. [PR 61](https://github.com/mlb-rs/mlbt/pull/61)
+  a game in the Schedule view and a more detailed breakdown in Gameday view.
+  Press `w` to toggle the win probability graphs on or off. [PR 61](https://github.com/mlb-rs/mlbt/pull/61)
 - Add selection for at bats in Gameday view. Use `j` and `k` to scroll through
   at bats and see all the pitches and events for that at bat. [PR 59](https://github.com/mlb-rs/mlbt/pull/59)
 - Add a spinning loader when API calls are in flight: [PR 56](https://github.com/mlb-rs/mlbt/pull/56)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1082,7 +1082,7 @@ dependencies = [
 
 [[package]]
 name = "mlbt"
-version = "0.0.16-alpha.3"
+version = "0.0.16-alpha.4"
 dependencies = [
  "anyhow",
  "better-panic",
@@ -1663,9 +1663,9 @@ dependencies = [
 
 [[package]]
 name = "serde_spanned"
-version = "0.6.8"
+version = "0.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87607cb1398ed59d48732e575a4c28a7a8ebf2454b964fe3f224f2afc07909e1"
+checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
 dependencies = [
  "serde",
 ]
@@ -1960,9 +1960,9 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.8.22"
+version = "0.8.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05ae329d1f08c4d17a59bed7ff5b5a769d062e64a62d34a3261b219e62cd5aae"
+checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
 dependencies = [
  "serde",
  "serde_spanned",
@@ -1972,18 +1972,18 @@ dependencies = [
 
 [[package]]
 name = "toml_datetime"
-version = "0.6.9"
+version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3da5db5a963e24bc68be8b17b6fa82814bb22ee8660f192bb182771d498f09a3"
+checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "toml_edit"
-version = "0.22.26"
+version = "0.22.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "310068873db2c5b3e7659d2cc35d21855dbafa50d1ce336397c666e3cb08137e"
+checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
 dependencies = [
  "indexmap",
  "serde",
@@ -1995,9 +1995,9 @@ dependencies = [
 
 [[package]]
 name = "toml_write"
-version = "0.1.1"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfb942dfe1d8e29a7ee7fcbde5bd2b9a25fb89aa70caea2eba3bee836ff41076"
+checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
 name = "tower"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mlbt"
-version = "0.0.16-alpha.3"
+version = "0.0.16-alpha.4"
 authors = ["Andrew Schneider <andjschneider@gmail.com>"]
 edition = "2024"
 license = "MIT"
@@ -30,5 +30,5 @@ indexmap = "2.9.0"
 mlb-api = { path = "api", version = "0.0.15" }
 serde = { version = "1.0.219", features = ["derive"] }
 tokio = { version = "1.45.1", features = ["full"] }
-toml = "0.8.22"
+toml = "0.8.23"
 tui = { package = "ratatui", version = "0.29.0" }

--- a/src/components/boxscore.rs
+++ b/src/components/boxscore.rs
@@ -42,10 +42,10 @@ impl BatterBoxscore {
         // let header = vec!["player", "ab", "r", "h", "rbi", "bb", "so", "lob", "avg"];
         vec![
             format!(
-                "{} {} {}",
+                "{} {: <2} {}",
                 self.order,
+                self.position, // pad an extra space so 'C' is aligned with '1B'
                 self.name.split_whitespace().last().unwrap_or("-"),
-                self.position
             ),
             self.at_bats.to_string(),
             self.runs.to_string(),

--- a/src/components/constants.rs
+++ b/src/components/constants.rs
@@ -2,7 +2,7 @@ use crate::components::standings::Team;
 use std::collections::HashMap;
 use std::sync::LazyLock;
 
-/// This maps the `teamId` to the `shortName` for each division and league.
+/// This maps the `divisionId` to the `shortName` for each division and league.
 /// The team names are taken from the `divisions` endpoint.
 pub static DIVISIONS: LazyLock<HashMap<u16, &'static str>> = LazyLock::new(|| {
     HashMap::from([
@@ -30,50 +30,10 @@ pub static DIVISION_ORDERS: LazyLock<HashMap<u16, Vec<u16>>> = LazyLock::new(|| 
     ])
 });
 
-/// This maps the full name of a team to its short name. The short name is used in the boxscore.
-/// The team names are taken from the `teams` endpoint.
-pub static TEAM_NAMES: LazyLock<HashMap<&'static str, &'static str>> = LazyLock::new(|| {
-    HashMap::from([
-        ("Oakland Athletics", "Athletics"),
-        ("Athletics", "Athletics"),
-        ("Pittsburgh Pirates", "Pirates"),
-        ("San Diego Padres", "Padres"),
-        ("Seattle Mariners", "Mariners"),
-        ("San Francisco Giants", "Giants"),
-        ("St. Louis Cardinals", "Cardinals"),
-        ("Tampa Bay Rays", "Rays"),
-        ("Texas Rangers", "Rangers"),
-        ("Toronto Blue Jays", "Blue Jays"),
-        ("Minnesota Twins", "Twins"),
-        ("Philadelphia Phillies", "Phillies"),
-        ("Atlanta Braves", "Braves"),
-        ("Chicago White Sox", "White Sox"),
-        ("Miami Marlins", "Marlins"),
-        ("Florida Marlins", "Marlins"),
-        ("New York Yankees", "Yankees"),
-        ("Milwaukee Brewers", "Brewers"),
-        ("Los Angeles Angels", "Angels"),
-        ("Arizona Diamondbacks", "D-backs"),
-        ("Baltimore Orioles", "Orioles"),
-        ("Boston Red Sox", "Red Sox"),
-        ("Chicago Cubs", "Cubs"),
-        ("Cincinnati Reds", "Reds"),
-        ("Cleveland Indians", "Indians"),
-        ("Cleveland Guardians", "Guardians"),
-        ("Colorado Rockies", "Rockies"),
-        ("Detroit Tigers", "Tigers"),
-        ("Houston Astros", "Astros"),
-        ("Kansas City Royals", "Royals"),
-        ("Los Angeles Dodgers", "Dodgers"),
-        ("Washington Nationals", "Nationals"),
-        ("New York Mets", "Mets"),
-        ("American League All-Stars", "AL All-Stars"),
-        ("National League All-Stars", "NL All-Stars"),
-    ])
-});
-
-#[rustfmt::skip]
+/// This maps the full name of a team to its full `Team` struct.
+/// The data is from the `teams` endpoint.
 // TODO generate from json?
+#[rustfmt::skip]
 pub static TEAM_IDS: LazyLock<HashMap<&'static str, Team>> = LazyLock::new(|| {
     let mut m = HashMap::new();
     m.insert("Oakland Athletics", Team { id: 133, division_id: 200, name: "Athletics", team_name: "Athletics", abbreviation: "ATH" });
@@ -109,5 +69,7 @@ pub static TEAM_IDS: LazyLock<HashMap<&'static str, Team>> = LazyLock::new(|| {
     m.insert("Los Angeles Dodgers", Team { id: 119, division_id: 203, name: "Los Angeles Dodgers", team_name: "Dodgers", abbreviation: "LAD" });
     m.insert("Washington Nationals", Team { id: 120, division_id: 204, name: "Washington Nationals", team_name: "Nationals", abbreviation: "WSH" });
     m.insert("New York Mets", Team { id: 121, division_id: 204, name: "New York Mets", team_name: "Mets", abbreviation: "NYM" });
+    m.insert("American League All-Stars", Team { id: 159, division_id: 103, name: "American League All-Stars", team_name: "AL All-Stars", abbreviation: "AL" });
+    m.insert("National League All-Stars", Team { id: 160, division_id: 104, name: "National League All-Stars", team_name: "NL All-Stars", abbreviation: "NL" });
     m
 });

--- a/src/components/constants.rs
+++ b/src/components/constants.rs
@@ -32,7 +32,7 @@ pub static DIVISION_ORDERS: LazyLock<HashMap<u16, Vec<u16>>> = LazyLock::new(|| 
 
 /// This maps the full name of a team to its full `Team` struct.
 /// The data is from the `teams` endpoint.
-// TODO generate from json?
+// TODO generate from API?
 #[rustfmt::skip]
 pub static TEAM_IDS: LazyLock<HashMap<&'static str, Team>> = LazyLock::new(|| {
     let mut m = HashMap::new();
@@ -44,6 +44,7 @@ pub static TEAM_IDS: LazyLock<HashMap<&'static str, Team>> = LazyLock::new(|| {
     m.insert("San Francisco Giants", Team { id: 137, division_id: 203, name: "San Francisco Giants", team_name: "Giants", abbreviation: "SF" });
     m.insert("St. Louis Cardinals", Team { id: 138, division_id: 205, name: "St. Louis Cardinals", team_name: "Cardinals", abbreviation: "STL" });
     m.insert("Tampa Bay Rays", Team { id: 139, division_id: 201, name: "Tampa Bay Rays", team_name: "Rays", abbreviation: "TB" });
+    m.insert("Tampa Bay Devil Rays", Team { id: 139, division_id: 201, name: "Tampa Bay Devil Rays", team_name: "Devil Rays", abbreviation: "TB" });
     m.insert("Texas Rangers", Team { id: 140, division_id: 200, name: "Texas Rangers", team_name: "Rangers", abbreviation: "TEX" });
     m.insert("Toronto Blue Jays", Team { id: 141, division_id: 201, name: "Toronto Blue Jays", team_name: "Blue Jays", abbreviation: "TOR" });
     m.insert("Minnesota Twins", Team { id: 142, division_id: 202, name: "Minnesota Twins", team_name: "Twins", abbreviation: "MIN" });
@@ -54,7 +55,10 @@ pub static TEAM_IDS: LazyLock<HashMap<&'static str, Team>> = LazyLock::new(|| {
     m.insert("Miami Marlins", Team { id: 146, division_id: 204, name: "Miami Marlins", team_name: "Marlins", abbreviation: "MIA" });
     m.insert("New York Yankees", Team { id: 147, division_id: 201, name: "New York Yankees", team_name: "Yankees", abbreviation: "NYY" });
     m.insert("Milwaukee Brewers", Team { id: 158, division_id: 205, name: "Milwaukee Brewers", team_name: "Brewers", abbreviation: "MIL" });
+    m.insert("Seattle Pilots", Team { id: 158, division_id: 200, name: "Seattle Pilots", team_name: "Pilots", abbreviation: "SEA" });
     m.insert("Los Angeles Angels", Team { id: 108, division_id: 200, name: "Los Angeles Angels", team_name: "Angels", abbreviation: "LAA" });
+    m.insert("Anaheim Angels", Team { id: 108, division_id: 200, name: "Anaheim Angels", team_name: "Angels", abbreviation: "ANA" });
+    m.insert("California Angels", Team { id: 108, division_id: 200, name: "California Angels", team_name: "Angels", abbreviation: "CAL" });
     m.insert("Arizona Diamondbacks", Team { id: 109, division_id: 203, name: "Arizona Diamondbacks", team_name: "D-backs", abbreviation: "AZ" });
     m.insert("Baltimore Orioles", Team { id: 110, division_id: 201, name: "Baltimore Orioles", team_name: "Orioles", abbreviation: "BAL" });
     m.insert("Boston Red Sox", Team { id: 111, division_id: 201, name: "Boston Red Sox", team_name: "Red Sox", abbreviation: "BOS" });
@@ -68,8 +72,19 @@ pub static TEAM_IDS: LazyLock<HashMap<&'static str, Team>> = LazyLock::new(|| {
     m.insert("Kansas City Royals", Team { id: 118, division_id: 202, name: "Kansas City Royals", team_name: "Royals", abbreviation: "KC" });
     m.insert("Los Angeles Dodgers", Team { id: 119, division_id: 203, name: "Los Angeles Dodgers", team_name: "Dodgers", abbreviation: "LAD" });
     m.insert("Washington Nationals", Team { id: 120, division_id: 204, name: "Washington Nationals", team_name: "Nationals", abbreviation: "WSH" });
+    m.insert("Montreal Expos", Team { id: 120, division_id: 204, name: "Montreal Expos", team_name: "Expos", abbreviation: "MON" });
     m.insert("New York Mets", Team { id: 121, division_id: 204, name: "New York Mets", team_name: "Mets", abbreviation: "NYM" });
     m.insert("American League All-Stars", Team { id: 159, division_id: 103, name: "American League All-Stars", team_name: "AL All-Stars", abbreviation: "AL" });
     m.insert("National League All-Stars", Team { id: 160, division_id: 104, name: "National League All-Stars", team_name: "NL All-Stars", abbreviation: "NL" });
+    // pre 1969 teams didn't have divisions so just setting it to `0`
+    m.insert("Houston Colt 45's", Team { id: 117, division_id: 0, name: "Houston Colt 45's", team_name: "Colt 45's", abbreviation: "HOU" });
+    m.insert("Kansas City Athletics", Team { id: 133, division_id: 0, name: "Kansas City Athletics", team_name: "Athletics", abbreviation: "KCA" });
+    m.insert("Washington Senators", Team { id: 140, division_id: 0, name: "Washington Senators", team_name: "Senators", abbreviation: "WAS" });
+    m.insert("Milwaukee Braves", Team { id: 144, division_id: 0, name: "Milwaukee Braves", team_name: "Braves", abbreviation: "MIL" });
+    m.insert("Cincinnati Redlegs", Team { id: 113, division_id: 0, name: "Cincinnati Redlegs", team_name: "Redlegs", abbreviation: "CIN" });
+    m.insert("Philadelphia Athletics", Team { id: 133, division_id: 0, name: "Philadelphia Athletics", team_name: "Athletics", abbreviation: "PHA" });
+    m.insert("Brooklyn Dodgers", Team { id: 119, division_id: 0, name: "Brooklyn Dodgers", team_name: "Dodgers", abbreviation: "BRO" });
+    m.insert("New York Giants", Team { id: 137, division_id: 0, name: "New York Giants", team_name: "Giants", abbreviation: "NYG" });
+    m.insert("Boston Braves", Team { id: 144, division_id: 0, name: "Boston Braves", team_name: "Braves", abbreviation: "BSN" });
     m
 });

--- a/src/ui/schedule.rs
+++ b/src/ui/schedule.rs
@@ -1,43 +1,61 @@
-use crate::components::schedule::{ScheduleRow, ScheduleState};
+use crate::components::schedule::{Record, ScheduleRow, ScheduleState};
 use crate::state::app_state::HomeOrAway;
 use tui::prelude::*;
 use tui::widgets::{Block, BorderType, Borders, Cell, Padding, Row, Table};
 
-const HEADER: &[&str; 6] = &["away", "", "home", "", "time", "status"];
+const HEADER: &[&str; 8] = &["away", "", "", "home", "", "", "time", "status"];
 
 pub struct ScheduleWidget {
     pub tz_abbreviation: String,
 }
 
 impl ScheduleRow {
-    fn format(&self) -> Vec<Span> {
+    const ABBREVIATION_WIDTH: u16 = 70;
+
+    fn format_record(record: Option<Record>) -> String {
+        record
+            .map(|r| r.to_display_string())
+            .unwrap_or(Record::default_display_string())
+    }
+
+    fn default_score(score: Option<u8>) -> String {
+        let s = score
+            .map(|s| s.to_string())
+            .unwrap_or_else(|| "-".to_string());
+        format!("{:<3}", s)
+    }
+
+    fn get_styles(&self, team: HomeOrAway) -> (Style, Style) {
         let winning_team = self.winning_team();
-
-        fn default_score(score: Option<u8>) -> String {
-            match score {
-                Some(s) => s.to_string(),
-                _ => "-".to_string(),
-            }
-        }
         let lose_style = Style::default().fg(Color::Gray);
+        match winning_team {
+            Some(winner) if winner == team => (Style::default(), Style::default()),
+            None => (Style::default(), Style::default()),
+            _ => (lose_style, lose_style),
+        }
+    }
 
-        let away_score = match winning_team {
-            Some(HomeOrAway::Away) => Span::raw(format!("{:<3}", default_score(self.away_score))),
-            _ => Span::styled(format!("{:<3}", default_score(self.away_score)), lose_style),
-        };
+    fn format(&self, width: u16) -> Vec<Span> {
+        let (away_team_style, away_score_style) = self.get_styles(HomeOrAway::Away);
+        let (home_team_style, home_score_style) = self.get_styles(HomeOrAway::Home);
+        let away_record = Self::format_record(self.away_record);
+        let home_record = Self::format_record(self.home_record);
 
-        let home_score = match winning_team {
-            Some(HomeOrAway::Home) => Span::raw(format!("{:<6}", default_score(self.home_score))),
-            _ => Span::styled(format!("{:<6}", default_score(self.home_score)), lose_style),
+        let (away_team, home_team) = if width < Self::ABBREVIATION_WIDTH {
+            (self.away_team.abbreviation, self.home_team.abbreviation)
+        } else {
+            (self.away_team.team_name, self.home_team.team_name)
         };
 
         vec![
-            Span::raw(format!("{:10}", self.away_team)),
-            away_score,
-            Span::raw(format!("{:10}", self.home_team)),
-            home_score,
-            Span::raw(format!("{:14}", self.start_time)),
-            Span::raw(format!("{:20}", self.game_status)),
+            Span::styled(away_team, away_team_style),
+            Span::styled(away_record, away_team_style),
+            Span::styled(Self::default_score(self.away_score), away_score_style),
+            Span::styled(home_team, home_team_style),
+            Span::styled(home_record, home_team_style),
+            Span::styled(Self::default_score(self.home_score), home_score_style),
+            Span::raw(self.start_time.to_string()),
+            Span::raw(self.game_status.to_string()),
         ]
     }
 }
@@ -47,7 +65,7 @@ impl StatefulWidget for ScheduleWidget {
 
     fn render(self, area: Rect, buf: &mut Buffer, state: &mut Self::State) {
         let header_cells = HEADER.iter().enumerate().map(|(i, h)| {
-            if i == 4 {
+            if i == 6 {
                 Cell::from(format!("{} [{}]", *h, self.tz_abbreviation))
             } else {
                 Cell::from(*h)
@@ -58,16 +76,26 @@ impl StatefulWidget for ScheduleWidget {
             .height(1)
             .style(Style::default().add_modifier(Modifier::BOLD | Modifier::UNDERLINED));
 
-        let rows = state.schedule.iter().map(|r| Row::new(r.format()));
-        let selected_style = Style::default().bg(Color::Blue).fg(Color::Black);
+        let rows = state
+            .schedule
+            .iter()
+            .map(|r| Row::new(r.format(area.width)));
+        let name_constraint = if area.width < ScheduleRow::ABBREVIATION_WIDTH {
+            Constraint::Length(5)
+        } else {
+            Constraint::Length(11)
+        };
         let widths = [
-            Constraint::Length(10), // away team name
+            name_constraint,        // away team name
+            Constraint::Length(6),  // away team record
             Constraint::Length(3),  // away score
-            Constraint::Length(10), // home team name
-            Constraint::Length(6),  // home score + padding
-            Constraint::Length(14), // game time
-            Constraint::Length(20), // game status
+            name_constraint,        // home team name
+            Constraint::Length(6),  // home team record
+            Constraint::Length(3),  // home score
+            Constraint::Length(12), // game time
+            Constraint::Length(10), // game status
         ];
+        let selected_style = Style::default().bg(Color::Blue).fg(Color::Black);
 
         let t = Table::new(rows, widths)
             .header(header)


### PR DESCRIPTION
- Added the current team record to the schedule
- Changed the losing team to be completely greyed out instead of just the losing score 
- If the terminal is too narrow the team names will change to the abbreviations 

<img width="593" alt="image" src="https://github.com/user-attachments/assets/8590719b-8c1d-40fc-9255-7592a0751392" />
