### PR TITLE
Add API logging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add selection for at bats in Gameday view. Use `j` and `k` to scroll through
   at bats and see all the pitches and events for that at bat. [PR 59](https://github.com/mlb-rs/mlbt/pull/59)
 - Add a spinning loader when API calls are in flight: [PR 56](https://github.com/mlb-rs/mlbt/pull/56)
+- Add configurable logging for API calls: [PR 66](https://github.com/mlb-rs/mlbt/pull/66)
 
 ## [0.0.15] - 2025-06-03
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -119,6 +119,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1628fb46dfa0b37568d12e5edd512553eccf6a22a78e8bde00bb4aed84d5bdbf"
 
 [[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
+
+[[package]]
 name = "bytes"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -443,6 +449,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "env_filter"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "186e05a59d4c50738528153b83b0b0194d3a29507dfec16eccd4b342903397d0"
+dependencies = [
+ "log",
+ "regex",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -537,6 +553,15 @@ dependencies = [
  "futures-task",
  "pin-project-lite",
  "pin-utils",
+]
+
+[[package]]
+name = "fxhash"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c31b6d751ae2c7f11320402d34e41349dd1016f8d5d45e48c4312bc8625af50c"
+dependencies = [
+ "byteorder",
 ]
 
 [[package]]
@@ -970,6 +995,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+
+[[package]]
 name = "libc"
 version = "0.2.171"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1069,7 +1100,7 @@ dependencies = [
 
 [[package]]
 name = "mlb-api"
-version = "0.0.16"
+version = "0.1.0"
 dependencies = [
  "chrono",
  "derive_builder",
@@ -1082,7 +1113,7 @@ dependencies = [
 
 [[package]]
 name = "mlbt"
-version = "0.0.16-alpha.5"
+version = "0.0.16-alpha.6"
 dependencies = [
  "anyhow",
  "better-panic",
@@ -1091,11 +1122,13 @@ dependencies = [
  "crossterm 0.29.0",
  "directories",
  "indexmap",
+ "log",
  "mlb-api",
  "ratatui",
  "serde",
  "tokio",
  "toml",
+ "tui-logger",
 ]
 
 [[package]]
@@ -1463,9 +1496,9 @@ checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "reqwest"
-version = "0.12.19"
+version = "0.12.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2f8e5513d63f2e5b386eb5106dc67eaf3f84e95258e210489136b8b92ad6119"
+checksum = "eabf4c97d9130e2bf606614eb937e86edac8292eaa6f422f995d7e8de1eb1813"
 dependencies = [
  "base64",
  "bytes",
@@ -1479,12 +1512,10 @@ dependencies = [
  "hyper-rustls",
  "hyper-tls",
  "hyper-util",
- "ipnet",
  "js-sys",
  "log",
  "mime",
  "native-tls",
- "once_cell",
  "percent-encoding",
  "pin-project-lite",
  "rustls-pki-types",
@@ -2068,6 +2099,22 @@ name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
+name = "tui-logger"
+version = "0.17.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57ea457a31a3fff1073f83e5c9e1c61a7805c435b2476b1df3a78f934adebabe"
+dependencies = [
+ "chrono",
+ "env_filter",
+ "fxhash",
+ "lazy_static",
+ "log",
+ "parking_lot",
+ "ratatui",
+ "unicode-segmentation",
+]
 
 [[package]]
 name = "unicode-ident"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mlbt"
-version = "0.0.16-alpha.5"
+version = "0.0.16-alpha.6"
 authors = ["Andrew Schneider <andjschneider@gmail.com>"]
 edition = "2024"
 license = "MIT"
@@ -27,8 +27,10 @@ chrono-tz = { version = "0.10.3", features = ["serde"] }
 crossterm = "0.29.0"
 directories = "6.0.0"
 indexmap = "2.9.0"
-mlb-api = { path = "api", version = "0.0.16" }
+log = "0.4.27"
+mlb-api = { path = "api", version = "0.1.0" }
 serde = { version = "1.0.219", features = ["derive"] }
 tokio = { version = "1.45.1", features = ["full"] }
 toml = "0.8.23"
 tui = { package = "ratatui", version = "0.29.0" }
+tui-logger = { version = "0.17.3", features = ["crossterm"] }

--- a/README.md
+++ b/README.md
@@ -220,6 +220,7 @@ back to the current day, enter `today` or `t`.
 
 - `?`: display help box
 - `Esc`: close help box
+- `"`: display logs
 
 > If your terminal is too small to display the full help box, the border will be
 > displayed red.
@@ -239,7 +240,7 @@ directory. For a user named `Alice` this would be:
 
 - `favorite_team`: This will make that team always show up first in the schedule
   if they have a game that day.
-  See [here](https://github.com/mlb-rs/mlbt/blob/main/src/components/constants.rs#L21)
+  See [here](https://github.com/mlb-rs/mlbt/blob/main/src/components/constants.rs#L37)
   for options (note: use the full name and not the short name).
 - `timezone`: This will change the time zone of the start time for the games in
   the schedule. The default is `US/Pacific`. Some common options are:
@@ -249,6 +250,9 @@ directory. For a user named `Alice` this would be:
     * `US/Eastern`
     * For the full list
       see [here](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones)
+- `log_level`: Set the log level to be displayed. If not present, `error` level
+  is used. Use a lowercase word, e.g. `debug`. See [here](https://github.com/mlb-rs/mlbt/blob/main/src/config.rs#L16)
+  for the options.
 
 ### Example config
 
@@ -256,6 +260,7 @@ directory. For a user named `Alice` this would be:
 # See https://github.com/mlb-rs/mlbt#config for options
 favorite_team = "Chicago Cubs"
 timezone = "US/Pacific"
+log_levl = "error"
 ```
 
 ## Shout out

--- a/api/Cargo.toml
+++ b/api/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
 name = "mlb-api"
-version = "0.0.16"
+version = "0.1.0"
 authors = ["Andrew Schneider <andjschneider@gmail.com>"]
 edition = "2024"
 
 [dependencies]
 chrono = "0.4.41"
 derive_builder = "0.20.2"
-reqwest = { version = "0.12.19", features = ["json"] }
+reqwest = { version = "0.12.20", features = ["json"] }
 serde = { version = "1.0.219", features = ["derive"] }
 serde_json = "1.0.140"
 

--- a/api/tests/client.rs
+++ b/api/tests/client.rs
@@ -3,6 +3,7 @@ use mlb_api::client::MLBApi;
 use mlb_api::client::MLBApiBuilder;
 use mlb_api::client::StatGroup;
 use mockito::{Matcher, ServerGuard};
+use std::time::Duration;
 
 async fn generate_mock_client() -> (MLBApi, ServerGuard) {
     let server = mockito::Server::new_async().await;
@@ -15,6 +16,7 @@ async fn generate_mock_client() -> (MLBApi, ServerGuard) {
 
     let client = MLBApiBuilder::default()
         .base_url(&formatted_url)
+        .timeout(Duration::from_secs(10))
         .build()
         .unwrap();
 
@@ -39,7 +41,7 @@ mod tests {
             .create();
 
         let date = NaiveDate::from_ymd_opt(2021, 7, 13).unwrap();
-        let resp = client.get_schedule_date(date).await;
+        let resp = client.get_schedule_date(date).await.unwrap();
         m.assert(); // assert mock was called
         assert_eq!(resp.total_games, 1);
     }
@@ -59,7 +61,7 @@ mod tests {
             .with_body_from_file("./tests/responses/standings.json")
             .create();
 
-        let resp = client.get_standings(date).await;
+        let resp = client.get_standings(date).await.unwrap();
         m.assert(); // assert mock was called
         assert_ne!(resp.records.len(), 0);
     }
@@ -77,7 +79,7 @@ mod tests {
             .with_body_from_file("./tests/responses/live.json")
             .create();
 
-        let resp = client.get_live_data(game_id).await;
+        let resp = client.get_live_data(game_id).await.unwrap();
         m.assert(); // assert mock was called
         assert_eq!(resp.game_pk, game_id);
     }
@@ -101,7 +103,7 @@ mod tests {
                 .with_body_from_file(format!("./tests/responses/team-stats-{group}.json"))
                 .create();
 
-            let resp = client.get_team_stats(group).await;
+            let resp = client.get_team_stats(group).await.unwrap();
             m.assert(); // assert mock was called
             assert_ne!(resp.stats.len(), 0);
             assert_eq!(resp.stats[0].group.display_name, group.to_string());
@@ -128,7 +130,7 @@ mod tests {
                 .with_body_from_file(format!("./tests/responses/team-stats-{group}-date.json"))
                 .create();
 
-            let resp = client.get_team_stats_on_date(group, date).await;
+            let resp = client.get_team_stats_on_date(group, date).await.unwrap();
             m.assert(); // assert mock was called
             assert_ne!(resp.stats.len(), 0);
             assert_eq!(resp.stats[0].group.display_name, group.to_string());
@@ -154,7 +156,7 @@ mod tests {
                 .with_body_from_file(format!("./tests/responses/player-stats-{group}.json"))
                 .create();
 
-            let resp = client.get_player_stats(group).await;
+            let resp = client.get_player_stats(group).await.unwrap();
             m.assert(); // assert mock was called
             assert_ne!(resp.stats.len(), 0);
             assert_eq!(resp.stats[0].group.display_name, group.to_string());
@@ -181,7 +183,7 @@ mod tests {
                 .with_body_from_file(format!("./tests/responses/player-stats-{group}-date.json"))
                 .create();
 
-            let resp = client.get_player_stats_on_date(group, date).await;
+            let resp = client.get_player_stats_on_date(group, date).await.unwrap();
             m.assert(); // assert mock was called
             assert_ne!(resp.stats.len(), 0);
             assert_eq!(resp.stats[0].group.display_name, group.to_string());

--- a/src/app.rs
+++ b/src/app.rs
@@ -42,6 +42,12 @@ impl App {
     fn configure(&mut self) {
         self.set_all_datepickers_to_today();
         self.state.standings.favorite_team = self.settings.favorite_team;
+
+        // override log level if set
+        if let Some(level) = self.settings.log_level {
+            log::set_max_level(level);
+            tui_logger::set_default_level(level);
+        }
     }
 
     /// Sync date pickers using the correct timezone.
@@ -139,6 +145,10 @@ impl App {
             DebugState::Off => self.state.debug_state = DebugState::On,
             DebugState::On => self.state.debug_state = DebugState::Off,
         }
+    }
+
+    pub fn toggle_show_logs(&mut self) {
+        self.state.show_logs = !self.state.show_logs;
     }
 
     pub fn toggle_full_screen(&mut self) {

--- a/src/components/debug.rs
+++ b/src/components/debug.rs
@@ -1,5 +1,4 @@
 use crate::app::App;
-use crate::components::game::win_probability::WinProbabilityAtBat;
 use std::fmt;
 use tui::Frame;
 
@@ -8,7 +7,6 @@ pub struct DebugInfo {
     pub gameday_url: String,
     pub terminal_width: u16,
     pub terminal_height: u16,
-    pub win_probability: WinProbabilityAtBat,
     pub selected_at_bat: Option<u8>,
 }
 
@@ -16,12 +14,11 @@ impl fmt::Display for DebugInfo {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(
             f,
-            "game id: {}, gameday: {}\nterminal height: {} width: {}\n{:?}\n{:?}",
+            "game id: {}, gameday: {}\nterminal height: {} width: {}\nselected at bat: {:?}",
             self.game_id.unwrap_or_default(),
             self.gameday_url,
             self.terminal_height,
             self.terminal_width,
-            self.win_probability,
             self.selected_at_bat,
         )
     }
@@ -34,7 +31,6 @@ impl DebugInfo {
             gameday_url: "https://www.mlb.com/scores".to_string(),
             terminal_width: 0,
             terminal_height: 0,
-            win_probability: WinProbabilityAtBat::default(),
             selected_at_bat: None,
         }
     }
@@ -49,15 +45,6 @@ impl DebugInfo {
         );
         self.terminal_width = f.area().width;
         self.terminal_height = f.area().height;
-        self.win_probability = app
-            .state
-            .gameday
-            .game
-            .win_probability
-            .at_bats
-            .get(&app.state.gameday.selected_at_bat().unwrap_or_default())
-            .cloned()
-            .unwrap_or_default();
         self.selected_at_bat = app.state.gameday.selected_at_bat();
     }
 }

--- a/src/components/util.rs
+++ b/src/components/util.rs
@@ -1,3 +1,4 @@
+use log::error;
 use tui::style::Color;
 
 /// Convert a string from the API to a Color::Rgb. The string starts out as:
@@ -11,7 +12,7 @@ pub(crate) fn convert_color(s: String) -> Color {
             c[2].parse().unwrap_or(0),
         )
     } else {
-        eprintln!("color doesn't start with 'rgba(' {:?}", s);
+        error!("color doesn't start with 'rgba(' {:?}", s);
         Color::Rgb(0, 0, 0)
     }
 }

--- a/src/keys.rs
+++ b/src/keys.rs
@@ -1,4 +1,4 @@
-use crate::app::{App, MenuItem};
+use crate::app::{App, DebugState, MenuItem};
 use crate::components::stats::TeamOrPlayer;
 use crate::state::app_state::HomeOrAway;
 use crate::{NetworkRequest, cleanup_terminal};
@@ -136,6 +136,12 @@ pub async fn handle_key_bindings(
         (_, Char('?')) => guard.update_tab(MenuItem::Help),
         (MenuItem::Help, KeyCode::Esc) => guard.exit_help(),
         (_, Char('d')) => guard.toggle_debug(),
+        (MenuItem::Help, Char('"')) => guard.toggle_show_logs(),
+        (_, Char('"')) => {
+            if guard.state.debug_state == DebugState::On {
+                guard.toggle_show_logs();
+            }
+        }
 
         _ => {}
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,6 +12,7 @@ use crate::state::network::{LoadingState, NetworkWorker};
 use crate::state::refresher::PeriodicRefresher;
 use crossterm::event::{self as crossterm_event, Event};
 use crossterm::{cursor, execute, terminal};
+use log::error;
 use std::io::Stdout;
 use std::sync::Arc;
 use std::{io, panic};
@@ -27,6 +28,10 @@ async fn main() -> anyhow::Result<()> {
 
     setup_panic_hook();
     setup_terminal();
+
+    // initialize logging
+    tui_logger::init_logger(log::LevelFilter::Error)?;
+    tui_logger::set_default_level(log::LevelFilter::Error);
 
     let app = Arc::new(Mutex::new(App::new()));
 
@@ -152,7 +157,7 @@ async fn handle_network_response(
             guard.state.stats.update(&stats);
         }
         NetworkResponse::Error { message } => {
-            eprintln!("Network error: {}", message);
+            error!("Network error: {message}");
         }
     }
     // Only redraw if not loading

--- a/src/state/app_settings.rs
+++ b/src/state/app_settings.rs
@@ -1,6 +1,7 @@
 use crate::components::standings::Team;
 use crate::config::ConfigFile;
 use chrono_tz::Tz;
+use log::{LevelFilter, error};
 
 #[derive(Debug, Default, Clone)]
 pub struct AppSettings {
@@ -8,6 +9,7 @@ pub struct AppSettings {
     pub full_screen: bool,
     pub timezone: Tz,
     pub timezone_abbreviation: String,
+    pub log_level: Option<LevelFilter>,
 }
 
 impl AppSettings {
@@ -15,7 +17,7 @@ impl AppSettings {
     pub fn load_from_file() -> Self {
         ConfigFile::load_from_file()
             .unwrap_or_else(|err| {
-                eprintln!("could not load config file: {:?}", err);
+                error!("could not load config file: {err}");
                 ConfigFile::default()
             })
             .into()

--- a/src/state/app_state.rs
+++ b/src/state/app_state.rs
@@ -18,6 +18,7 @@ pub struct AppState {
     pub active_tab: MenuItem,
     pub previous_tab: MenuItem,
     pub debug_state: DebugState,
+    pub show_logs: bool,
     pub date_input: DateInput,
     pub schedule: ScheduleState,
     pub gameday: GamedayState,

--- a/src/state/network.rs
+++ b/src/state/network.rs
@@ -1,13 +1,15 @@
 use crate::components::stats::{StatType, TeamOrPlayer};
 use crate::{NetworkRequest, NetworkResponse};
 use chrono::NaiveDate;
-use mlb_api::client::{MLBApi, MLBApiBuilder};
+use log::{debug, error};
+use mlb_api::client::{ApiResult, MLBApi, MLBApiBuilder};
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::Duration;
 use tokio::sync::mpsc;
 
 const SPINNER_CHARS: [char; 10] = ['⠋', '⠙', '⠹', '⠸', '⠼', '⠴', '⠦', '⠧', '⠇', '⠏'];
+pub const ERROR_CHAR: char = '!';
 
 #[derive(Debug, Copy, Clone)]
 pub struct LoadingState {
@@ -47,7 +49,7 @@ impl NetworkWorker {
     pub async fn run(mut self) {
         while let Some(request) = self.requests.recv().await {
             self.start_loading_animation().await;
-            let response = match request {
+            let result = match request {
                 NetworkRequest::Schedule { date } => self.handle_load_schedule(date).await,
                 NetworkRequest::GameData { game_id } => self.handle_load_game_data(game_id).await,
                 NetworkRequest::Standings { date } => self.handle_load_standings(date).await,
@@ -55,49 +57,54 @@ impl NetworkWorker {
                     self.handle_load_stats(date, stat_type).await
                 }
             };
-            self.stop_loading_animation().await;
+            debug!("request complete");
+            self.stop_loading_animation(result.is_ok()).await;
 
-            if let Some(response) = response {
-                if let Err(e) = self.responses.send(response).await {
-                    eprintln!("Failed to send network response: {}", e);
-                    break;
-                }
+            let response =
+                result.unwrap_or_else(|err| NetworkResponse::Error { message: err.log() });
+            if let Err(e) = self.responses.send(response).await {
+                error!("Failed to send network response: {e}");
+                break;
             }
         }
     }
 
-    async fn handle_load_schedule(&self, date: NaiveDate) -> Option<NetworkResponse> {
-        let schedule = self.client.get_schedule_date(date).await;
-        Some(NetworkResponse::ScheduleLoaded { schedule })
+    async fn handle_load_schedule(&self, date: NaiveDate) -> ApiResult<NetworkResponse> {
+        debug!("loading schedule for {date}");
+        let schedule = self.client.get_schedule_date(date).await?;
+        Ok(NetworkResponse::ScheduleLoaded { schedule })
     }
 
-    async fn handle_load_game_data(&self, game_id: u64) -> Option<NetworkResponse> {
+    async fn handle_load_game_data(&self, game_id: u64) -> ApiResult<NetworkResponse> {
+        debug!("loading game data for {game_id}");
         let (game, wp) = tokio::join!(
             self.client.get_live_data(game_id),
             self.client.get_win_probability(game_id),
         );
-        Some(NetworkResponse::GameDataLoaded {
-            game: Box::new(game),
-            win_probability: wp,
+        Ok(NetworkResponse::GameDataLoaded {
+            game: Box::new(game?),
+            win_probability: wp?,
         })
     }
 
-    async fn handle_load_standings(&self, date: NaiveDate) -> Option<NetworkResponse> {
-        let standings = self.client.get_standings(date).await;
-        Some(NetworkResponse::StandingsLoaded { standings })
+    async fn handle_load_standings(&self, date: NaiveDate) -> ApiResult<NetworkResponse> {
+        debug!("loading standings for {date}");
+        let standings = self.client.get_standings(date).await?;
+        Ok(NetworkResponse::StandingsLoaded { standings })
     }
 
     async fn handle_load_stats(
         &self,
         date: NaiveDate,
         stat_type: StatType,
-    ) -> Option<NetworkResponse> {
+    ) -> ApiResult<NetworkResponse> {
+        debug!("loading {stat_type:?} stats for {date}");
         let StatType { team_player, group } = stat_type;
         let stats = match team_player {
             TeamOrPlayer::Team => self.client.get_team_stats_on_date(group, date).await,
             TeamOrPlayer::Player => self.client.get_player_stats_on_date(group, date).await,
-        };
-        Some(NetworkResponse::StatsLoaded { stats })
+        }?;
+        Ok(NetworkResponse::StatsLoaded { stats })
     }
 
     async fn start_loading_animation(&self) {
@@ -142,17 +149,26 @@ impl NetworkWorker {
         });
     }
 
-    async fn stop_loading_animation(&self) {
+    async fn stop_loading_animation(&self, is_ok: bool) {
         self.is_loading.store(false, Ordering::Relaxed);
 
         // Add a small delay to ensure the animation task stops
         tokio::time::sleep(Duration::from_millis(15)).await;
 
+        let loading_state = match is_ok {
+            true => LoadingState {
+                is_loading: false,
+                spinner_char: ' ',
+            },
+            false => LoadingState {
+                is_loading: false,
+                spinner_char: ERROR_CHAR,
+            },
+        };
+
         let _ = self
             .responses
-            .send(NetworkResponse::LoadingStateChanged {
-                loading_state: LoadingState::default(),
-            })
+            .send(NetworkResponse::LoadingStateChanged { loading_state })
             .await;
     }
 }

--- a/src/ui/debug.rs
+++ b/src/ui/debug.rs
@@ -1,22 +1,23 @@
 use crate::components::debug::DebugInfo;
+use crate::ui::logs::LogWidget;
 use tui::layout::Constraint::Percentage;
 use tui::prelude::*;
-use tui::widgets::{Block, Borders, Clear, Paragraph};
+use tui::widgets::{Block, Clear, Paragraph};
 
 impl DebugInfo {
-    pub fn render(&self, f: &mut Frame, rect: Rect) {
-        let [_, debug] = Layout::vertical([Percentage(80), Percentage(20)]).areas(rect);
+    pub fn render(&self, f: &mut Frame, rect: Rect, show_logs: bool) {
+        let [_, area] = Layout::vertical([Percentage(80), Percentage(20)]).areas(rect);
 
-        let help = Paragraph::new(self.to_string())
+        let debug = Paragraph::new(self.to_string())
             .alignment(Alignment::Left)
-            .block(
-                Block::default()
-                    .borders(Borders::ALL)
-                    .border_style(Style::default()),
-            )
+            .block(Block::bordered().title("debug"))
             .style(Style::default().fg(Color::White));
 
-        f.render_widget(Clear, debug); //this clears out the background
-        f.render_widget(help, debug);
+        f.render_widget(Clear, area); //this clears out the background
+        if show_logs {
+            f.render_widget(LogWidget {}, area);
+        } else {
+            f.render_widget(debug, area);
+        }
     }
 }

--- a/src/ui/help.rs
+++ b/src/ui/help.rs
@@ -1,12 +1,8 @@
-use tui::{
-    buffer::Buffer,
-    layout::{Alignment, Constraint, Flex, Layout, Rect},
-    style::{Modifier, Style},
-    widgets::{Paragraph, Row, Table, Widget},
-};
-
 use crate::components::banner::BANNER;
 use crate::config::ConfigFile;
+use tui::layout::{Alignment, Constraint, Flex, Layout};
+use tui::prelude::{Buffer, Modifier, Rect, Style};
+use tui::widgets::{Paragraph, Row, Table, Widget};
 
 const HEADER: &[&str; 2] = &["Description", "Key"];
 pub const DOCS: &[&[&str; 2]; 33] = &[

--- a/src/ui/logs.rs
+++ b/src/ui/logs.rs
@@ -1,0 +1,26 @@
+use tui::prelude::Color;
+use tui::widgets::Block;
+use tui::{buffer::Buffer, layout::Rect, style::Style, widgets::Widget};
+use tui_logger::{TuiLoggerLevelOutput, TuiLoggerWidget};
+
+pub struct LogWidget {}
+
+impl Widget for LogWidget {
+    fn render(self, area: Rect, buf: &mut Buffer) {
+        TuiLoggerWidget::default()
+            .block(Block::bordered().title("logs"))
+            .style_error(Style::default().fg(Color::Red))
+            .style_warn(Style::default().fg(Color::Yellow))
+            .style_info(Style::default().fg(Color::Cyan))
+            .style_debug(Style::default().fg(Color::Green))
+            .style_trace(Style::default().fg(Color::Magenta))
+            .output_separator('|')
+            .output_timestamp(Some("%F %H:%M:%S%.3f".to_string()))
+            .output_level(Some(TuiLoggerLevelOutput::Long))
+            .output_target(false)
+            .output_file(false)
+            .output_line(false)
+            .style(Style::default().fg(Color::White))
+            .render(area, buf);
+    }
+}

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -5,6 +5,7 @@ pub(crate) mod gameday;
 pub(crate) mod help;
 pub(crate) mod layout;
 pub(crate) mod linescore;
+pub(crate) mod logs;
 pub(crate) mod schedule;
 pub(crate) mod standings;
 pub(crate) mod stats;


### PR DESCRIPTION
This adds logging for API calls. The log level can be configured with the config file, with the default level as error. The logs are displayed using the [tui-logger crate](https://github.com/gin66/tui-logger)

full screen logs in the Help screen:
<img width="770" alt="Screenshot 2025-06-22 at 3 24 26 PM" src="https://github.com/user-attachments/assets/0c19b113-f559-449a-a09b-0048e4733ddf" />

overlay logs in the Debug screen:
<img width="671" alt="Screenshot 2025-06-22 at 3 24 04 PM" src="https://github.com/user-attachments/assets/ff7c6565-cd42-4910-ac48-7a7e753f0363" />
