### PR TITLE
Add team abbreviation to player stats

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1113,7 +1113,7 @@ dependencies = [
 
 [[package]]
 name = "mlbt"
-version = "0.0.16"
+version = "0.0.17-alpha.1"
 dependencies = [
  "anyhow",
  "better-panic",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mlbt"
-version = "0.0.16"
+version = "0.0.17-alpha.1"
 authors = ["Andrew Schneider <andjschneider@gmail.com>"]
 edition = "2024"
 license = "MIT"


### PR DESCRIPTION
Shows the team abbreviation when viewing player stats 

<img width="608" alt="image" src="https://github.com/user-attachments/assets/371503cc-115e-47f6-9d48-d4368b5f826f" />
