### PR TITLE
Display outs in bold

### DIFF
--- a/src/ui/gameday/plays.rs
+++ b/src/ui/gameday/plays.rs
@@ -141,7 +141,7 @@ fn format_score(play: &PlayResult) -> Span {
 fn format_outs(play: &PlayResult) -> Span {
     if play.is_out {
         let out = if play.count.outs == 1 { "out" } else { "outs" };
-        Span::raw(format!(" {} {}", &play.count.outs, out))
+        Span::raw(format!(" {} {}", &play.count.outs, out)).bold()
     } else {
         Span::raw("")
     }


### PR DESCRIPTION
Since the Gameday log entries are pretty dense, I've found it quite helpful to display the outs in bold, like on the Gameday website.

| Before | After |
|-|-|
| <img width="422" alt="image" src="https://github.com/user-attachments/assets/dafbe6ed-1cad-4c3a-af2f-33e9a0618d53" /> | <img width="424" alt="image" src="https://github.com/user-attachments/assets/376068c1-26d4-4438-8911-7105c9fa4ad4" /> |

Feel free to close this PR if it doesn't align with your vision for the interface!