### PR TITLE
Scrollable boxscore

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,15 +142,17 @@ Press `f` for full screen mode to hide the tab bar.
 
 Press `1` to activate this tab.
 
-| Key       | Description                                            |
-|-----------|--------------------------------------------------------|
-| `j` / `↓` | move down                                              |
-| `k` / `↑` | move up                                                |
-| `Enter`   | view current game in Gameday                           |
-| `:`       | activate date picker (see [Date Picker](#date-picker)) |
-| `w`       | toggle win probability graph                           |
-| `h`       | switch to home team in boxscore                        |
-| `a`       | switch to away team in boxscore                        |
+| Key                 | Description                                            |
+|---------------------|--------------------------------------------------------|
+| `j` / `↓`           | move down                                              |
+| `k` / `↑`           | move up                                                |
+| `Enter`             | view current game in Gameday                           |
+| `:`                 | activate date picker (see [Date Picker](#date-picker)) |
+| `w`                 | toggle win probability graph                           |
+| `h`                 | switch to home team in box score                       |
+| `a`                 | switch to away team in box score                       |
+| `Shift` +  `j`/ `↓` | scroll box score down                                  |
+| `Shift` +  `k`/ `↑` | scroll box score up                                    |
 
 ### Gameday
 
@@ -163,7 +165,7 @@ toggled on and off using:
 |-----|------------------------------|
 | `i` | info pane                    |
 | `p` | pitches pane                 |
-| `b` | boxscore pane                |
+| `b` | box score pane               |
 | `w` | toggle win probability graph |
 
 To view different at bats in the game, use:
@@ -175,12 +177,14 @@ To view different at bats in the game, use:
 | `l`       | move to the "live" play, or latest available |
 | `s`       | move to first play of the game               |
 
-To switch the team displayed in the box score:
+To interact with the box score, use:
 
-| Key | Description                     |
-|-----|---------------------------------|
-| `h` | switch to home team in boxscore |
-| `a` | switch to away team in boxscore |
+| Key                 | Description                      |
+|---------------------|----------------------------------|
+| `h`                 | switch to home team in box score |
+| `a`                 | switch to away team in box score |
+| `Shift` +  `j`/ `↓` | scroll box score down            |
+| `Shift` +  `k`/ `↑` | scroll box score up              |
 
 ### Stats
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -86,6 +86,17 @@ impl App {
         // this prevents gameday from showing incorrect data if the user scrolls through games quickly
         if Some(live_data.game_pk) == self.state.schedule.get_selected_game_opt() {
             self.state.gameday.game.update(live_data, win_probability);
+            // update this after the gameday so the players are correct
+            self.state
+                .boxscore_state
+                .update(live_data, &self.state.gameday.game.players);
+
+            // only reset the scroll state if on the scoreboard tab. this will reset when a new game
+            // is selected or the data refreshes. don't reset the scroll in Gameday because that
+            // happens too frequently and makes it hard to read the box score
+            if self.state.active_tab == MenuItem::Scoreboard {
+                self.state.boxscore_state.reset_scroll();
+            }
         }
     }
 
@@ -99,9 +110,17 @@ impl App {
         self.state.active_tab = next;
         self.state.debug_state = DebugState::Off;
 
-        // reset selection when switching tabs but not when date picker is opened
+        // reset standings selection when switching tabs but not when date picker is opened
         if next != MenuItem::DatePicker && self.state.previous_tab == MenuItem::Standings {
             self.state.standings.reset_selection();
+        }
+
+        // reset boxscore scroll
+        if next != MenuItem::DatePicker
+            && (self.state.previous_tab == MenuItem::Scoreboard
+                || self.state.previous_tab == MenuItem::Gameday)
+        {
+            self.state.boxscore_state.reset_scroll();
         }
     }
 

--- a/src/components/boxscore.rs
+++ b/src/components/boxscore.rs
@@ -203,12 +203,6 @@ impl PitcherBoxscore {
 }
 
 impl Boxscore {
-    const BATTING_HEADER: &'static [&'static str] =
-        &["player", "ab", "r", "h", "rbi", "bb", "k", "lob", "avg"];
-
-    const PITCHING_HEADER: &'static [&'static str] =
-        &["pitcher", "ip", "h", "r", "er", "bb", "k", "hr", "era"];
-
     const BLANK_LINE_SENTINEL: &'static str = "****";
     const HEADER_SENTINEL: &'static str = "header";
 
@@ -361,10 +355,13 @@ impl Boxscore {
         batters
     }
 
-    pub fn to_batting_table_rows(&self, active: HomeOrAway) -> Vec<Vec<Cell>> {
+    pub fn to_batting_table_rows<'a>(
+        &'a self,
+        active: HomeOrAway,
+    ) -> impl Iterator<Item = Vec<Cell<'a>>> + 'a {
         match active {
-            HomeOrAway::Home => self.home_batting.iter().map(|p| p.to_cells()).collect(),
-            HomeOrAway::Away => self.away_batting.iter().map(|p| p.to_cells()).collect(),
+            HomeOrAway::Home => self.home_batting.iter().map(BatterBoxscore::to_cells),
+            HomeOrAway::Away => self.away_batting.iter().map(BatterBoxscore::to_cells),
         }
     }
 
@@ -375,14 +372,13 @@ impl Boxscore {
         }
     }
 
-    pub fn get_batting_header(&self) -> &'static [&'static str] {
-        Self::BATTING_HEADER
-    }
-
-    pub fn to_pitching_table_rows(&self, active: HomeOrAway) -> Vec<Vec<Cell>> {
+    pub fn to_pitching_table_rows<'a>(
+        &'a self,
+        active: HomeOrAway,
+    ) -> impl Iterator<Item = Vec<Cell<'a>>> + 'a {
         match active {
-            HomeOrAway::Home => self.home_pitching.iter().map(|p| p.to_cells()).collect(),
-            HomeOrAway::Away => self.away_pitching.iter().map(|p| p.to_cells()).collect(),
+            HomeOrAway::Home => self.home_pitching.iter().map(PitcherBoxscore::to_cells),
+            HomeOrAway::Away => self.away_pitching.iter().map(PitcherBoxscore::to_cells),
         }
     }
 
@@ -391,10 +387,6 @@ impl Boxscore {
             HomeOrAway::Home => self.home_pitching.len(),
             HomeOrAway::Away => self.away_pitching.len(),
         }
-    }
-
-    pub fn get_pitching_header(&self) -> &'static [&'static str] {
-        Self::PITCHING_HEADER
     }
 
     pub fn get_batting_notes(&self, active: HomeOrAway) -> &[Note] {

--- a/src/components/game/live_game.rs
+++ b/src/components/game/live_game.rs
@@ -1,4 +1,3 @@
-use crate::components::boxscore::Boxscore;
 use crate::components::constants::TEAM_IDS;
 use crate::components::game::at_bat::AtBat;
 use crate::components::game::player::{Player, PlayerStats};
@@ -24,7 +23,6 @@ pub struct GameState {
     pub home_team: Team,
     pub away_team: Team,
     pub linescore: LineScore,
-    pub boxscore: Boxscore,
     pub current_at_bat: AtBatIndex,
     pub at_bats: IndexMap<AtBatIndex, AtBat>,
     pub on_deck: Option<PlayerId>,
@@ -44,7 +42,6 @@ impl GameState {
         self.set_teams(live_data);
         self.set_on_deck(live_data);
         self.current_at_bat = Self::get_current_play_ab_index(live_data);
-        self.boxscore = Boxscore::from_live_data(live_data, &self.players);
         self.linescore = LineScore::from_live_data(live_data);
         if let Some(plays) = &live_data.live_data.plays.all_plays {
             plays.iter().for_each(|p| Self::update_single_play(self, p));

--- a/src/draw.rs
+++ b/src/draw.rs
@@ -176,14 +176,14 @@ fn draw_linescore_boxscore(f: &mut Frame, rect: Rect, app: &mut App) {
 
     f.render_widget(
         LineScoreWidget {
-            active: app.state.boxscore_state.team,
+            active: app.state.boxscore_state.active_team,
             linescore: &app.state.gameday.game.linescore,
         },
         chunks[0],
     );
     f.render_widget(
         TeamBatterBoxscoreWidget {
-            active: app.state.boxscore_state.team,
+            active: app.state.boxscore_state.active_team,
             state: &mut app.state.boxscore_state,
         },
         chunks[1],
@@ -204,7 +204,7 @@ fn draw_date_picker(f: &mut Frame, rect: Rect, app: &mut App) {
 fn draw_gameday(f: &mut Frame, rect: Rect, app: &mut App) {
     f.render_widget(
         GamedayWidget {
-            active: app.state.boxscore_state.team,
+            active: app.state.boxscore_state.active_team,
             state: &app.state.gameday,
             boxscore_state: &mut app.state.boxscore_state,
         },

--- a/src/draw.rs
+++ b/src/draw.rs
@@ -171,20 +171,20 @@ fn draw_scoreboard(f: &mut Frame, rect: Rect, app: &mut App) {
     draw_linescore_boxscore(f, boxscore, app);
 }
 
-fn draw_linescore_boxscore(f: &mut Frame, rect: Rect, app: &App) {
+fn draw_linescore_boxscore(f: &mut Frame, rect: Rect, app: &mut App) {
     let chunks = LayoutAreas::for_boxscore(rect);
 
     f.render_widget(
         LineScoreWidget {
-            active: app.state.boxscore_tab,
+            active: app.state.boxscore_state.team,
             linescore: &app.state.gameday.game.linescore,
         },
         chunks[0],
     );
     f.render_widget(
         TeamBatterBoxscoreWidget {
-            active: app.state.boxscore_tab,
-            boxscore: &app.state.gameday.game.boxscore,
+            active: app.state.boxscore_state.team,
+            state: &mut app.state.boxscore_state,
         },
         chunks[1],
     );
@@ -201,11 +201,12 @@ fn draw_date_picker(f: &mut Frame, rect: Rect, app: &mut App) {
     ))
 }
 
-fn draw_gameday(f: &mut Frame, rect: Rect, app: &App) {
+fn draw_gameday(f: &mut Frame, rect: Rect, app: &mut App) {
     f.render_widget(
         GamedayWidget {
-            active: app.state.boxscore_tab,
+            active: app.state.boxscore_state.team,
             state: &app.state.gameday,
+            boxscore_state: &mut app.state.boxscore_state,
         },
         rect,
     );

--- a/src/keys.rs
+++ b/src/keys.rs
@@ -15,132 +15,139 @@ pub async fn handle_key_bindings(
     app: &Arc<Mutex<App>>,
     network_requests: &mpsc::Sender<NetworkRequest>,
 ) {
-    // handle quit keys before acquiring the lock
-    match (key_event.code, key_event.modifiers) {
-        (Char('q'), _) | (Char('c'), KeyModifiers::CONTROL) => {
+    let mut guard = app.lock().await;
+    match (guard.state.active_tab, key_event.code, key_event.modifiers) {
+        (_, Char('q'), _) | (_, Char('c'), KeyModifiers::CONTROL) => {
             cleanup_terminal();
             std::process::exit(0);
         }
-        _ => {}
-    }
-
-    let mut guard = app.lock().await;
-    match (guard.state.active_tab, key_event.code) {
         // needs to be before the tab switches to capture number inputs
-        (MenuItem::DatePicker, Char(c)) => {
+        (MenuItem::DatePicker, Char(c), _) => {
             guard.state.date_input.is_valid = true; // reset status
             guard.state.date_input.text.push(c);
         }
 
-        (_, Char('f')) => guard.toggle_full_screen(),
-        (_, Char('1')) => {
+        (_, Char('f'), _) => guard.toggle_full_screen(),
+        (_, Char('1'), _) => {
             guard.update_tab(MenuItem::Scoreboard);
             guard.state.gameday.live(); // reset at bat selection
             load_scoreboard(guard, network_requests).await;
         }
-        (_, Char('2')) => {
+        (_, Char('2'), _) => {
             guard.update_tab(MenuItem::Gameday);
             load_game_data(guard, network_requests).await;
         }
-        (_, Char('3')) => {
+        (_, Char('3'), _) => {
             guard.update_tab(MenuItem::Stats);
             load_stats(guard, network_requests).await;
         }
-        (_, Char('4')) => {
+        (_, Char('4'), _) => {
             guard.update_tab(MenuItem::Standings);
             load_standings(guard, network_requests).await;
         }
 
-        (MenuItem::Scoreboard, Char('j') | KeyCode::Down) => {
+        (MenuItem::Scoreboard, Char('J') | KeyCode::Down, KeyModifiers::SHIFT) => {
+            guard.state.boxscore_state.scroll_down()
+        }
+        (MenuItem::Scoreboard, Char('j') | KeyCode::Down, _) => {
             guard.state.schedule.next();
             load_game_data(guard, network_requests).await;
         }
-        (MenuItem::Scoreboard, Char('k') | KeyCode::Up) => {
+        (MenuItem::Scoreboard, Char('K') | KeyCode::Up, KeyModifiers::SHIFT) => {
+            guard.state.boxscore_state.scroll_up()
+        }
+        (MenuItem::Scoreboard, Char('k') | KeyCode::Up, _) => {
             guard.state.schedule.previous();
             load_game_data(guard, network_requests).await;
         }
-        (MenuItem::Scoreboard, Char(':')) => guard.update_tab(MenuItem::DatePicker),
-        (MenuItem::Scoreboard, Char('w')) => guard.state.schedule.toggle_win_probability(),
-        (MenuItem::Scoreboard, KeyCode::Enter) => {
+        (MenuItem::Scoreboard, Char(':'), _) => guard.update_tab(MenuItem::DatePicker),
+        (MenuItem::Scoreboard, Char('w'), _) => guard.state.schedule.toggle_win_probability(),
+        (MenuItem::Scoreboard, KeyCode::Enter, _) => {
             guard.update_tab(MenuItem::Gameday);
             load_game_data(guard, network_requests).await;
         }
 
-        (MenuItem::DatePicker, KeyCode::Enter) => {
+        (MenuItem::DatePicker, KeyCode::Enter, _) => {
             if guard.try_update_date_from_input().is_ok() {
                 let previous_tab = guard.state.previous_tab;
                 guard.update_tab(previous_tab);
                 handle_date_change(guard, network_requests).await;
             }
         }
-        (MenuItem::DatePicker, KeyCode::Right) => {
+        (MenuItem::DatePicker, KeyCode::Right, _) => {
             guard.move_date_selector_by_arrow(true);
         }
-        (MenuItem::DatePicker, KeyCode::Left) => {
+        (MenuItem::DatePicker, KeyCode::Left, _) => {
             guard.move_date_selector_by_arrow(false);
         }
-        (MenuItem::DatePicker, KeyCode::Esc) => {
+        (MenuItem::DatePicker, KeyCode::Esc, _) => {
             guard.state.date_input.text.clear();
             let previous_tab = guard.state.previous_tab;
             guard.update_tab(previous_tab);
         }
-        (MenuItem::DatePicker, KeyCode::Backspace) => {
+        (MenuItem::DatePicker, KeyCode::Backspace, _) => {
             guard.state.date_input.text.pop();
         }
 
-        (MenuItem::Stats, Char('j') | KeyCode::Down) => guard.state.stats.next(),
-        (MenuItem::Stats, Char('k') | KeyCode::Up) => guard.state.stats.previous(),
-        (MenuItem::Stats, Char('o')) => {
+        (MenuItem::Stats, Char('j') | KeyCode::Down, _) => guard.state.stats.next(),
+        (MenuItem::Stats, Char('k') | KeyCode::Up, _) => guard.state.stats.previous(),
+        (MenuItem::Stats, Char('o'), _) => {
             guard.state.stats.show_options = !guard.state.stats.show_options
         }
-        (MenuItem::Stats, Char('p')) => {
+        (MenuItem::Stats, Char('p'), _) => {
             guard.state.stats.stat_type.group = StatGroup::Pitching;
             load_stats(guard, network_requests).await;
         }
-        (MenuItem::Stats, Char('h')) => {
+        (MenuItem::Stats, Char('h'), _) => {
             guard.state.stats.stat_type.group = StatGroup::Hitting;
             load_stats(guard, network_requests).await;
         }
-        (MenuItem::Stats, Char('l')) => {
+        (MenuItem::Stats, Char('l'), _) => {
             guard.state.stats.stat_type.team_player = TeamOrPlayer::Player;
             load_stats(guard, network_requests).await;
         }
-        (MenuItem::Stats, Char('t')) => {
+        (MenuItem::Stats, Char('t'), _) => {
             guard.state.stats.stat_type.team_player = TeamOrPlayer::Team;
             load_stats(guard, network_requests).await;
         }
-        (MenuItem::Stats, KeyCode::Enter) => guard.state.stats.toggle_stat(),
-        (MenuItem::Stats, Char('s')) => guard.state.stats.store_sort_column(),
-        (MenuItem::Stats, Char(':')) => guard.update_tab(MenuItem::DatePicker),
+        (MenuItem::Stats, KeyCode::Enter, _) => guard.state.stats.toggle_stat(),
+        (MenuItem::Stats, Char('s'), _) => guard.state.stats.store_sort_column(),
+        (MenuItem::Stats, Char(':'), _) => guard.update_tab(MenuItem::DatePicker),
 
-        (MenuItem::Standings, Char('j') | KeyCode::Down) => guard.state.standings.next(),
-        (MenuItem::Standings, Char('k') | KeyCode::Up) => guard.state.standings.previous(),
-        (MenuItem::Standings, KeyCode::Enter) => {
+        (MenuItem::Standings, Char('j') | KeyCode::Down, _) => guard.state.standings.next(),
+        (MenuItem::Standings, Char('k') | KeyCode::Up, _) => guard.state.standings.previous(),
+        (MenuItem::Standings, KeyCode::Enter, _) => {
             let _team_id = guard.state.standings.get_selected();
             // println!("team id: {:?}", team_id);
             // TODO show team info panel
         }
-        (MenuItem::Standings, Char(':')) => guard.update_tab(MenuItem::DatePicker),
+        (MenuItem::Standings, Char(':'), _) => guard.update_tab(MenuItem::DatePicker),
 
-        (MenuItem::Gameday, Char('i')) => guard.state.gameday.toggle_info(),
-        (MenuItem::Gameday, Char('p')) => guard.state.gameday.toggle_at_bat(),
-        (MenuItem::Gameday, Char('b')) => guard.state.gameday.toggle_boxscore(),
-        (MenuItem::Gameday, Char('w')) => guard.state.gameday.toggle_win_probability(),
-        (MenuItem::Gameday, Char('j') | KeyCode::Down) => guard.state.gameday.previous_at_bat(),
-        (MenuItem::Gameday, Char('k') | KeyCode::Up) => guard.state.gameday.next_at_bat(),
-        (MenuItem::Gameday, Char('l')) => guard.state.gameday.live(),
-        (MenuItem::Gameday, Char('s')) => guard.state.gameday.start(),
+        (MenuItem::Gameday, Char('i'), _) => guard.state.gameday.toggle_info(),
+        (MenuItem::Gameday, Char('p'), _) => guard.state.gameday.toggle_at_bat(),
+        (MenuItem::Gameday, Char('b'), _) => guard.state.gameday.toggle_boxscore(),
+        (MenuItem::Gameday, Char('w'), _) => guard.state.gameday.toggle_win_probability(),
+        (MenuItem::Gameday, Char('J') | KeyCode::Down, KeyModifiers::SHIFT) => {
+            guard.state.boxscore_state.scroll_down()
+        }
+        (MenuItem::Gameday, Char('K') | KeyCode::Up, KeyModifiers::SHIFT) => {
+            guard.state.boxscore_state.scroll_up()
+        }
+        (MenuItem::Gameday, Char('j') | KeyCode::Down, _) => guard.state.gameday.previous_at_bat(),
+        (MenuItem::Gameday, Char('k') | KeyCode::Up, _) => guard.state.gameday.next_at_bat(),
+        (MenuItem::Gameday, Char('l'), _) => guard.state.gameday.live(),
+        (MenuItem::Gameday, Char('s'), _) => guard.state.gameday.start(),
 
-        (MenuItem::Gameday, Char('h')) => guard.state.boxscore_tab = HomeOrAway::Home,
-        (MenuItem::Gameday, Char('a')) => guard.state.boxscore_tab = HomeOrAway::Away,
-        (MenuItem::Scoreboard, Char('h')) => guard.state.boxscore_tab = HomeOrAway::Home,
-        (MenuItem::Scoreboard, Char('a')) => guard.state.boxscore_tab = HomeOrAway::Away,
+        (MenuItem::Gameday, Char('h'), _) => guard.state.boxscore_state.team = HomeOrAway::Home,
+        (MenuItem::Gameday, Char('a'), _) => guard.state.boxscore_state.team = HomeOrAway::Away,
+        (MenuItem::Scoreboard, Char('h'), _) => guard.state.boxscore_state.team = HomeOrAway::Home,
+        (MenuItem::Scoreboard, Char('a'), _) => guard.state.boxscore_state.team = HomeOrAway::Away,
 
-        (_, Char('?')) => guard.update_tab(MenuItem::Help),
-        (MenuItem::Help, KeyCode::Esc) => guard.exit_help(),
-        (_, Char('d')) => guard.toggle_debug(),
-        (MenuItem::Help, Char('"')) => guard.toggle_show_logs(),
-        (_, Char('"')) => {
+        (_, Char('?'), _) => guard.update_tab(MenuItem::Help),
+        (MenuItem::Help, KeyCode::Esc, _) => guard.exit_help(),
+        (_, Char('d'), _) => guard.toggle_debug(),
+        (MenuItem::Help, Char('"'), _) => guard.toggle_show_logs(),
+        (_, Char('"'), _) => {
             if guard.state.debug_state == DebugState::On {
                 guard.toggle_show_logs();
             }

--- a/src/keys.rs
+++ b/src/keys.rs
@@ -1,6 +1,5 @@
 use crate::app::{App, DebugState, MenuItem};
 use crate::components::stats::TeamOrPlayer;
-use crate::state::app_state::HomeOrAway;
 use crate::{NetworkRequest, cleanup_terminal};
 use crossterm::event::KeyCode::Char;
 use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
@@ -138,10 +137,10 @@ pub async fn handle_key_bindings(
         (MenuItem::Gameday, Char('l'), _) => guard.state.gameday.live(),
         (MenuItem::Gameday, Char('s'), _) => guard.state.gameday.start(),
 
-        (MenuItem::Gameday, Char('h'), _) => guard.state.boxscore_state.team = HomeOrAway::Home,
-        (MenuItem::Gameday, Char('a'), _) => guard.state.boxscore_state.team = HomeOrAway::Away,
-        (MenuItem::Scoreboard, Char('h'), _) => guard.state.boxscore_state.team = HomeOrAway::Home,
-        (MenuItem::Scoreboard, Char('a'), _) => guard.state.boxscore_state.team = HomeOrAway::Away,
+        (MenuItem::Gameday, Char('h'), _) => guard.state.boxscore_state.set_home_active(),
+        (MenuItem::Gameday, Char('a'), _) => guard.state.boxscore_state.set_away_active(),
+        (MenuItem::Scoreboard, Char('h'), _) => guard.state.boxscore_state.set_home_active(),
+        (MenuItem::Scoreboard, Char('a'), _) => guard.state.boxscore_state.set_away_active(),
 
         (_, Char('?'), _) => guard.update_tab(MenuItem::Help),
         (MenuItem::Help, KeyCode::Esc, _) => guard.exit_help(),

--- a/src/state/app_state.rs
+++ b/src/state/app_state.rs
@@ -2,6 +2,7 @@ use crate::app::{DebugState, MenuItem};
 use crate::components::schedule::ScheduleState;
 use crate::components::standings::StandingsState;
 use crate::components::stats::StatsState;
+use crate::state::boxscore::BoxscoreState;
 use crate::state::date_input::DateInput;
 use crate::state::gameday::GamedayState;
 
@@ -22,7 +23,7 @@ pub struct AppState {
     pub date_input: DateInput,
     pub schedule: ScheduleState,
     pub gameday: GamedayState,
-    pub boxscore_tab: HomeOrAway,
+    pub boxscore_state: BoxscoreState,
     pub standings: StandingsState,
     pub stats: StatsState,
 }

--- a/src/state/boxscore.rs
+++ b/src/state/boxscore.rs
@@ -24,15 +24,15 @@ pub struct BoxscoreRenderCache {
     pub home_batting_notes_paragraph: Option<Paragraph<'static>>,
     pub away_batting_notes_paragraph: Option<Paragraph<'static>>,
     pub game_notes_paragraph: Option<Paragraph<'static>>,
-    // Cached table heights
-    pub home_batting_height: u16,
-    pub away_batting_height: u16,
-    pub home_pitching_height: u16,
-    pub away_pitching_height: u16,
-    // Cached paragraph heights
-    pub home_notes_height: u16,
-    pub away_notes_height: u16,
-    pub game_notes_height: u16,
+    // Cache table heights
+    pub home_batting_stats_height: usize,
+    pub away_batting_stats_height: usize,
+    pub home_pitching_stats_height: usize,
+    pub away_pitching_stats_height: usize,
+    // Cache paragraph heights
+    pub home_batting_notes_height: usize,
+    pub away_batting_notes_height: usize,
+    pub game_notes_height: usize,
     pub home_total_content_height: u16,
     pub away_total_content_height: u16,
     // Track last viewport width to know when to recalculate
@@ -45,11 +45,6 @@ impl BoxscoreState {
         self.update_cache();
     }
 
-    pub fn reset_scroll(&mut self) {
-        self.scroll = 0;
-        self.scroll_state = ScrollbarState::default();
-    }
-
     fn update_cache(&mut self) {
         // cache full paragraphs to be used later to calculate height based on wrapped line length
         self.cache.home_batting_notes_paragraph =
@@ -59,10 +54,10 @@ impl BoxscoreState {
         self.cache.game_notes_paragraph = Self::build_paragraph(self.boxscore.get_game_notes());
 
         // calculate static table heights
-        self.cache.home_batting_height = self.boxscore.count_batting_table_rows(Home) as u16 + 1; // +1 for header
-        self.cache.away_batting_height = self.boxscore.count_batting_table_rows(Away) as u16 + 1; // +1 for header
-        self.cache.home_pitching_height = self.boxscore.count_pitching_table_rows(Home) as u16 + 1; // +1 for header
-        self.cache.away_pitching_height = self.boxscore.count_pitching_table_rows(Away) as u16 + 1; // +1 for header
+        self.cache.home_batting_stats_height = self.boxscore.count_batting_table_rows(Home) + 1; // +1 for header
+        self.cache.away_batting_stats_height = self.boxscore.count_batting_table_rows(Away) + 1; // +1 for header
+        self.cache.home_pitching_stats_height = self.boxscore.count_pitching_table_rows(Home) + 1; // +1 for header
+        self.cache.away_pitching_stats_height = self.boxscore.count_pitching_table_rows(Away) + 1; // +1 for header
 
         // Reset viewport width to force recalculation of wrapped content heights
         self.cache.last_viewport_width = 0;
@@ -81,46 +76,35 @@ impl BoxscoreState {
         }
     }
 
+    /// Calculate the height of wrapped text for the current viewport width and cache the results.
     fn calculate_heights_for_width(&mut self, viewport_width: u16) {
         if self.cache.last_viewport_width == viewport_width {
             // already calculated for this width
             return;
         }
 
-        // calculate wrapped text heights for current viewport width
-        self.cache.home_notes_height = self
-            .cache
-            .home_batting_notes_paragraph
-            .as_ref()
-            .map(|p| p.line_count(viewport_width) as u16)
-            .unwrap_or(0);
+        let line_count = |p: &Option<Paragraph<'static>>| -> usize {
+            p.as_ref()
+                .map(|p| p.line_count(viewport_width))
+                .unwrap_or(0)
+        };
 
-        self.cache.away_notes_height = self
-            .cache
-            .away_batting_notes_paragraph
-            .as_ref()
-            .map(|p| p.line_count(viewport_width) as u16)
-            .unwrap_or(0);
-
-        self.cache.game_notes_height = self
-            .cache
-            .game_notes_paragraph
-            .as_ref()
-            .map(|p| p.line_count(viewport_width) as u16)
-            .unwrap_or(0);
+        self.cache.home_batting_notes_height = line_count(&self.cache.home_batting_notes_paragraph);
+        self.cache.away_batting_notes_height = line_count(&self.cache.away_batting_notes_paragraph);
+        self.cache.game_notes_height = line_count(&self.cache.game_notes_paragraph);
 
         // calculate total content height for each team
-        self.cache.home_total_content_height = self.cache.home_batting_height
-            + self.cache.home_notes_height
-            + self.cache.home_pitching_height
+        self.cache.home_total_content_height = (self.cache.home_batting_stats_height
+            + self.cache.home_batting_notes_height
+            + self.cache.home_pitching_stats_height
             + self.cache.game_notes_height
-            + 3; // +3 for spacing
+            + 3) as u16; // +3 for spacing
 
-        self.cache.away_total_content_height = self.cache.away_batting_height
-            + self.cache.away_notes_height
-            + self.cache.away_pitching_height
+        self.cache.away_total_content_height = (self.cache.away_batting_stats_height
+            + self.cache.away_batting_notes_height
+            + self.cache.away_pitching_stats_height
             + self.cache.game_notes_height
-            + 3; // +3 for spacing
+            + 3) as u16; // +3 for spacing
 
         self.cache.last_viewport_width = viewport_width;
     }
@@ -148,20 +132,6 @@ impl BoxscoreState {
         }
     }
 
-    pub fn scroll_down(&mut self) {
-        if self.scroll < self.max_scroll {
-            self.scroll += 1;
-            self.scroll_state = self.scroll_state.position(self.scroll);
-        }
-    }
-
-    pub fn scroll_up(&mut self) {
-        if self.scroll > 0 {
-            self.scroll = self.scroll.saturating_sub(1);
-            self.scroll_state = self.scroll_state.position(self.scroll);
-        }
-    }
-
     pub fn get_batting_rows(&self, team: HomeOrAway) -> Vec<Vec<Cell>> {
         self.boxscore.to_batting_table_rows(team)
     }
@@ -181,25 +151,50 @@ impl BoxscoreState {
         self.cache.game_notes_paragraph.as_ref()
     }
 
-    pub fn get_content_heights(&self, team: HomeOrAway) -> (u16, u16, u16, u16) {
+    pub fn get_content_heights(&self, team: HomeOrAway) -> (u16, u16, u16, u16, u16) {
         let (batting_height, pitching_height, notes_height) = match team {
             Home => (
-                self.cache.home_batting_height,
-                self.cache.home_pitching_height,
-                self.cache.home_notes_height,
+                self.cache.home_batting_stats_height,
+                self.cache.home_pitching_stats_height,
+                self.cache.home_batting_notes_height,
             ),
             Away => (
-                self.cache.away_batting_height,
-                self.cache.away_pitching_height,
-                self.cache.away_notes_height,
+                self.cache.away_batting_stats_height,
+                self.cache.away_pitching_stats_height,
+                self.cache.away_batting_notes_height,
             ),
         };
 
+        let total_content_height = match self.team {
+            Home => self.cache.home_total_content_height,
+            Away => self.cache.away_total_content_height,
+        };
+
         (
-            batting_height,
-            notes_height,
-            pitching_height,
-            self.cache.game_notes_height,
+            batting_height as u16,
+            notes_height as u16,
+            pitching_height as u16,
+            self.cache.game_notes_height as u16,
+            total_content_height,
         )
+    }
+
+    pub fn reset_scroll(&mut self) {
+        self.scroll = 0;
+        self.scroll_state = ScrollbarState::default();
+    }
+
+    pub fn scroll_down(&mut self) {
+        if self.scroll < self.max_scroll {
+            self.scroll += 1;
+            self.scroll_state = self.scroll_state.position(self.scroll);
+        }
+    }
+
+    pub fn scroll_up(&mut self) {
+        if self.scroll > 0 {
+            self.scroll = self.scroll.saturating_sub(1);
+            self.scroll_state = self.scroll_state.position(self.scroll);
+        }
     }
 }

--- a/src/state/boxscore.rs
+++ b/src/state/boxscore.rs
@@ -1,0 +1,205 @@
+use crate::components::boxscore::{Boxscore, Note};
+use crate::components::game::live_game::PlayerId;
+use crate::components::game::player::Player;
+use crate::state::app_state::HomeOrAway;
+use crate::state::app_state::HomeOrAway::{Away, Home};
+use mlb_api::live::LiveResponse;
+use std::collections::HashMap;
+use tui::prelude::*;
+use tui::widgets::{Block, Cell, Paragraph, ScrollbarState, Wrap};
+
+#[derive(Default)]
+pub struct BoxscoreState {
+    pub team: HomeOrAway,
+    pub boxscore: Boxscore,
+    pub scroll: usize,
+    pub scroll_state: ScrollbarState,
+    pub cache: BoxscoreRenderCache,
+    pub max_scroll: usize,
+}
+
+#[derive(Default)]
+pub struct BoxscoreRenderCache {
+    // Cache paragraphs for length calculation
+    pub home_batting_notes_paragraph: Option<Paragraph<'static>>,
+    pub away_batting_notes_paragraph: Option<Paragraph<'static>>,
+    pub game_notes_paragraph: Option<Paragraph<'static>>,
+    // Cached table heights
+    pub home_batting_height: u16,
+    pub away_batting_height: u16,
+    pub home_pitching_height: u16,
+    pub away_pitching_height: u16,
+    // Cached paragraph heights
+    pub home_notes_height: u16,
+    pub away_notes_height: u16,
+    pub game_notes_height: u16,
+    pub home_total_content_height: u16,
+    pub away_total_content_height: u16,
+    // Track last viewport width to know when to recalculate
+    pub last_viewport_width: u16,
+}
+
+impl BoxscoreState {
+    pub fn update(&mut self, live_game: &LiveResponse, players: &HashMap<PlayerId, Player>) {
+        self.boxscore = Boxscore::from_live_data(live_game, players);
+        self.update_cache();
+    }
+
+    pub fn reset_scroll(&mut self) {
+        self.scroll = 0;
+        self.scroll_state = ScrollbarState::default();
+    }
+
+    fn update_cache(&mut self) {
+        // cache full paragraphs to be used later to calculate height based on wrapped line length
+        self.cache.home_batting_notes_paragraph =
+            Self::build_paragraph(self.boxscore.get_batting_notes(Home));
+        self.cache.away_batting_notes_paragraph =
+            Self::build_paragraph(self.boxscore.get_batting_notes(Away));
+        self.cache.game_notes_paragraph = Self::build_paragraph(self.boxscore.get_game_notes());
+
+        // calculate static table heights
+        self.cache.home_batting_height = self.boxscore.count_batting_table_rows(Home) as u16 + 1; // +1 for header
+        self.cache.away_batting_height = self.boxscore.count_batting_table_rows(Away) as u16 + 1; // +1 for header
+        self.cache.home_pitching_height = self.boxscore.count_pitching_table_rows(Home) as u16 + 1; // +1 for header
+        self.cache.away_pitching_height = self.boxscore.count_pitching_table_rows(Away) as u16 + 1; // +1 for header
+
+        // Reset viewport width to force recalculation of wrapped content heights
+        self.cache.last_viewport_width = 0;
+    }
+
+    fn build_paragraph(notes: &[Note]) -> Option<Paragraph<'static>> {
+        let lines: Vec<Line<'static>> = notes.iter().filter_map(|n| n.to_line()).collect();
+        if lines.is_empty() {
+            None
+        } else {
+            Some(
+                Paragraph::new(lines)
+                    .block(Block::default())
+                    .wrap(Wrap { trim: true }),
+            )
+        }
+    }
+
+    fn calculate_heights_for_width(&mut self, viewport_width: u16) {
+        if self.cache.last_viewport_width == viewport_width {
+            // already calculated for this width
+            return;
+        }
+
+        // calculate wrapped text heights for current viewport width
+        self.cache.home_notes_height = self
+            .cache
+            .home_batting_notes_paragraph
+            .as_ref()
+            .map(|p| p.line_count(viewport_width) as u16)
+            .unwrap_or(0);
+
+        self.cache.away_notes_height = self
+            .cache
+            .away_batting_notes_paragraph
+            .as_ref()
+            .map(|p| p.line_count(viewport_width) as u16)
+            .unwrap_or(0);
+
+        self.cache.game_notes_height = self
+            .cache
+            .game_notes_paragraph
+            .as_ref()
+            .map(|p| p.line_count(viewport_width) as u16)
+            .unwrap_or(0);
+
+        // calculate total content height for each team
+        self.cache.home_total_content_height = self.cache.home_batting_height
+            + self.cache.home_notes_height
+            + self.cache.home_pitching_height
+            + self.cache.game_notes_height
+            + 3; // +3 for spacing
+
+        self.cache.away_total_content_height = self.cache.away_batting_height
+            + self.cache.away_notes_height
+            + self.cache.away_pitching_height
+            + self.cache.game_notes_height
+            + 3; // +3 for spacing
+
+        self.cache.last_viewport_width = viewport_width;
+    }
+
+    pub fn update_scroll_state_for_viewport(&mut self, viewport_height: u16, viewport_width: u16) {
+        // use the height to determine height after text wrapping
+        self.calculate_heights_for_width(viewport_width);
+
+        let total_content_height = match self.team {
+            Home => self.cache.home_total_content_height,
+            Away => self.cache.away_total_content_height,
+        };
+
+        if total_content_height > viewport_height {
+            self.max_scroll = total_content_height.saturating_sub(viewport_height) as usize;
+            self.scroll = self.scroll.min(self.max_scroll);
+
+            self.scroll_state = self
+                .scroll_state
+                .content_length(total_content_height as usize)
+                .position(self.scroll);
+        } else {
+            self.max_scroll = 0;
+            self.scroll = 0;
+        }
+    }
+
+    pub fn scroll_down(&mut self) {
+        if self.scroll < self.max_scroll {
+            self.scroll += 1;
+            self.scroll_state = self.scroll_state.position(self.scroll);
+        }
+    }
+
+    pub fn scroll_up(&mut self) {
+        if self.scroll > 0 {
+            self.scroll = self.scroll.saturating_sub(1);
+            self.scroll_state = self.scroll_state.position(self.scroll);
+        }
+    }
+
+    pub fn get_batting_rows(&self, team: HomeOrAway) -> Vec<Vec<Cell>> {
+        self.boxscore.to_batting_table_rows(team)
+    }
+
+    pub fn get_pitching_rows(&self, team: HomeOrAway) -> Vec<Vec<Cell>> {
+        self.boxscore.to_pitching_table_rows(team)
+    }
+
+    pub fn get_batting_notes_paragraph(&self, team: HomeOrAway) -> Option<&Paragraph<'static>> {
+        match team {
+            Home => self.cache.home_batting_notes_paragraph.as_ref(),
+            Away => self.cache.away_batting_notes_paragraph.as_ref(),
+        }
+    }
+
+    pub fn get_game_notes_paragraph(&self) -> Option<&Paragraph<'static>> {
+        self.cache.game_notes_paragraph.as_ref()
+    }
+
+    pub fn get_content_heights(&self, team: HomeOrAway) -> (u16, u16, u16, u16) {
+        let (batting_height, pitching_height, notes_height) = match team {
+            Home => (
+                self.cache.home_batting_height,
+                self.cache.home_pitching_height,
+                self.cache.home_notes_height,
+            ),
+            Away => (
+                self.cache.away_batting_height,
+                self.cache.away_pitching_height,
+                self.cache.away_notes_height,
+            ),
+        };
+
+        (
+            batting_height,
+            notes_height,
+            pitching_height,
+            self.cache.game_notes_height,
+        )
+    }
+}

--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -1,5 +1,6 @@
 pub mod app_settings;
 pub mod app_state;
+pub mod boxscore;
 pub mod date_input;
 pub mod gameday;
 pub mod messages;

--- a/src/ui/boxscore.rs
+++ b/src/ui/boxscore.rs
@@ -37,21 +37,21 @@ impl Widget for TeamBatterBoxscoreWidget<'_> {
     fn render(self, area: Rect, buf: &mut Buffer) {
         self.state
             .update_scroll_state_for_viewport(area.height, area.width);
-        let total_content_height = match self.active {
-            HomeOrAway::Home => self.state.cache.home_total_content_height,
-            HomeOrAway::Away => self.state.cache.away_total_content_height,
-        };
-        let needs_scrolling = total_content_height > area.height;
+
+        let (
+            batting_height,
+            notes_height,
+            pitching_height,
+            game_notes_height,
+            total_content_height,
+        ) = self.state.get_content_heights(self.active);
 
         let batting_rows = self.state.get_batting_rows(self.active);
-        let pitching_rows = self.state.get_pitching_rows(self.active);
         let batting_notes_paragraph = self.state.get_batting_notes_paragraph(self.active);
+        let pitching_rows = self.state.get_pitching_rows(self.active);
         let game_notes_paragraph = self.state.get_game_notes_paragraph();
 
-        let (batting_height, notes_height, pitching_height, game_notes_height) =
-            self.state.get_content_heights(self.active);
-
-        if needs_scrolling {
+        if total_content_height > area.height {
             // Create a large virtual area for rendering
             let virtual_area = Rect {
                 x: area.x,

--- a/src/ui/boxscore.rs
+++ b/src/ui/boxscore.rs
@@ -1,7 +1,8 @@
-use crate::components::boxscore::Boxscore;
 use crate::state::app_state::HomeOrAway;
+use crate::state::boxscore::BoxscoreState;
 use tui::prelude::*;
-use tui::widgets::{Block, Paragraph, Row, Table, Wrap};
+use tui::symbols::scrollbar::DOUBLE_VERTICAL;
+use tui::widgets::{Block, Borders, Row, Scrollbar, ScrollbarOrientation, Table};
 
 const BATTER_WIDTHS: [Constraint; 9] = [
     Constraint::Length(25), // player name
@@ -29,63 +30,216 @@ const PITCHER_WIDTHS: [Constraint; 9] = [
 
 pub struct TeamBatterBoxscoreWidget<'a> {
     pub active: HomeOrAway,
-    pub boxscore: &'a Boxscore,
+    pub state: &'a mut BoxscoreState,
 }
 
 impl Widget for TeamBatterBoxscoreWidget<'_> {
     fn render(self, area: Rect, buf: &mut Buffer) {
-        let batting = self.boxscore.to_batting_table_rows(self.active);
-        let batting_notes = self
-            .boxscore
-            .get_batting_notes(self.active)
-            .iter()
-            .filter_map(|n| n.to_line());
-        let notes_paragraph = Paragraph::new(batting_notes.collect::<Vec<_>>())
-            .block(Block::default())
-            .wrap(Wrap { trim: true });
-        let pitching = self.boxscore.to_pitching_table_rows(self.active);
+        self.state
+            .update_scroll_state_for_viewport(area.height, area.width);
+        let total_content_height = match self.active {
+            HomeOrAway::Home => self.state.cache.home_total_content_height,
+            HomeOrAway::Away => self.state.cache.away_total_content_height,
+        };
+        let needs_scrolling = total_content_height > area.height;
 
-        let [boxscore, note, pitchers, game_notes] = Layout::vertical([
-            Constraint::Length(batting.len() as u16 + 1), // +1 for header
-            Constraint::Length(notes_paragraph.line_count(area.width) as u16),
-            Constraint::Length(pitching.len() as u16 + 1), // +1 for header
-            Constraint::Fill(1),
-        ])
-        .spacing(1)
-        .areas(area);
+        let batting_rows = self.state.get_batting_rows(self.active);
+        let pitching_rows = self.state.get_pitching_rows(self.active);
+        let batting_notes_paragraph = self.state.get_batting_notes_paragraph(self.active);
+        let game_notes_paragraph = self.state.get_game_notes_paragraph();
 
-        Widget::render(
-            Table::new(batting.into_iter().map(Row::new), BATTER_WIDTHS)
-                .column_spacing(0)
-                .header(
-                    Row::new(self.boxscore.get_batting_header().iter().copied())
-                        .bold()
-                        .underlined(),
-                ),
-            boxscore,
-            buf,
-        );
+        let (batting_height, notes_height, pitching_height, game_notes_height) =
+            self.state.get_content_heights(self.active);
 
-        Widget::render(notes_paragraph, note, buf);
+        if needs_scrolling {
+            // Create a large virtual area for rendering
+            let virtual_area = Rect {
+                x: area.x,
+                y: 0,
+                width: area.width,
+                height: total_content_height,
+            };
 
-        Widget::render(
-            Table::new(pitching.into_iter().map(Row::new), PITCHER_WIDTHS)
-                .column_spacing(0)
-                .header(
-                    Row::new(self.boxscore.get_pitching_header().iter().copied())
-                        .bold()
-                        .underlined(),
-                ),
-            pitchers,
-            buf,
-        );
+            // Calculate layout in virtual space
+            let [boxscore_area, notes_area, pitchers_area, game_notes_area] = Layout::vertical([
+                Constraint::Length(batting_height),
+                Constraint::Length(notes_height),
+                Constraint::Length(pitching_height),
+                Constraint::Length(game_notes_height),
+            ])
+            .spacing(1)
+            .areas(virtual_area);
 
-        Widget::render(
-            Paragraph::new(self.boxscore.get_game_notes())
-                .block(Block::default())
-                .wrap(Wrap { trim: true }),
-            game_notes,
-            buf,
-        );
+            // Adjust areas based on scroll position and clip to visible area
+            let scroll_offset = self.state.scroll as i32;
+            let visible_top = area.y as i32;
+            let visible_bottom = (area.y + area.height) as i32;
+
+            let adjust_area = |area: Rect| -> Option<Rect> {
+                let area_top = area.y as i32 - scroll_offset + visible_top;
+                let area_bottom = area_top + area.height as i32;
+
+                if area_bottom <= visible_top || area_top >= visible_bottom {
+                    return None; // Area is not visible
+                }
+
+                let clipped_top = area_top.max(visible_top);
+                let clipped_bottom = area_bottom.min(visible_bottom);
+                let clipped_height = (clipped_bottom - clipped_top) as u16;
+
+                if clipped_height > 0 {
+                    Some(Rect {
+                        x: area.x,
+                        y: clipped_top as u16,
+                        width: area.width,
+                        height: clipped_height,
+                    })
+                } else {
+                    None
+                }
+            };
+
+            // Render components that are visible
+            if let Some(visible_boxscore) = adjust_area(boxscore_area) {
+                Widget::render(
+                    Table::new(
+                        batting_rows
+                            .into_iter()
+                            .skip(scroll_offset as usize)
+                            .map(Row::new),
+                        BATTER_WIDTHS,
+                    )
+                    .column_spacing(0)
+                    .style(Style::default().fg(Color::White))
+                    .header(
+                        Row::new(self.state.boxscore.get_batting_header().iter().copied())
+                            .bold()
+                            .underlined(),
+                    )
+                    .block(Block::default().borders(Borders::NONE)),
+                    visible_boxscore,
+                    buf,
+                );
+            }
+
+            if let Some(visible_note) = adjust_area(notes_area) {
+                if let Some(paragraph) = batting_notes_paragraph {
+                    let offset = (scroll_offset as u16).saturating_sub(batting_height + 1); // +1 for space
+                    let scrolled = if offset > 0 {
+                        &paragraph.clone().scroll((offset, 0))
+                    } else {
+                        paragraph
+                    };
+                    Widget::render(scrolled, visible_note, buf);
+                }
+            }
+
+            if let Some(visible_pitchers) = adjust_area(pitchers_area) {
+                let offset = (scroll_offset as u16)
+                    .saturating_sub(batting_height + 1)
+                    .saturating_sub(notes_height + 1); // +1 for space
+                Widget::render(
+                    Table::new(
+                        pitching_rows
+                            .into_iter()
+                            .skip(offset as usize)
+                            .map(Row::new),
+                        PITCHER_WIDTHS,
+                    )
+                    .column_spacing(0)
+                    .style(Style::default().fg(Color::White))
+                    .header(
+                        Row::new(self.state.boxscore.get_pitching_header().iter().copied())
+                            .bold()
+                            .underlined(),
+                    )
+                    .block(Block::default().borders(Borders::NONE)),
+                    visible_pitchers,
+                    buf,
+                );
+            }
+
+            if let Some(visible_game_notes) = adjust_area(game_notes_area) {
+                if let Some(paragraph) = game_notes_paragraph {
+                    let offset = (scroll_offset as u16)
+                        .saturating_sub(batting_height + 1)
+                        .saturating_sub(notes_height + 1)
+                        .saturating_sub(pitching_height + 1); // +1 for space
+                    let scrolled = if offset > 0 {
+                        &paragraph.clone().scroll((offset, 0))
+                    } else {
+                        paragraph
+                    };
+
+                    Widget::render(scrolled, visible_game_notes, buf);
+                }
+            }
+
+            // Render scrollbar
+            let scrollbar_area = Rect {
+                x: area.x + area.width + 1, // + 1 to move it over the border
+                y: area.y,
+                width: 1,
+                height: area.height,
+            };
+
+            StatefulWidget::render(
+                Scrollbar::new(ScrollbarOrientation::VerticalRight)
+                    // use the same thumb and track symbol to hide the thumb
+                    .thumb_symbol(DOUBLE_VERTICAL.track)
+                    .track_symbol(Some(DOUBLE_VERTICAL.track))
+                    .begin_symbol(Some("↑"))
+                    .end_symbol(Some("↓")),
+                scrollbar_area,
+                buf,
+                &mut self.state.scroll_state,
+            );
+        } else {
+            // Render normally without scrolling
+            let [boxscore, note, pitchers, game_notes_area] = Layout::vertical([
+                Constraint::Length(batting_height),
+                Constraint::Length(notes_height),
+                Constraint::Length(pitching_height),
+                Constraint::Fill(1),
+            ])
+            .spacing(1)
+            .areas(area);
+
+            Widget::render(
+                Table::new(batting_rows.into_iter().map(Row::new), BATTER_WIDTHS)
+                    .column_spacing(0)
+                    .style(Style::default().fg(Color::White))
+                    .header(
+                        Row::new(self.state.boxscore.get_batting_header().iter().copied())
+                            .bold()
+                            .underlined(),
+                    )
+                    .block(Block::default().borders(Borders::NONE)),
+                boxscore,
+                buf,
+            );
+
+            if let Some(paragraph) = batting_notes_paragraph {
+                Widget::render(paragraph, note, buf);
+            }
+
+            Widget::render(
+                Table::new(pitching_rows.into_iter().map(Row::new), PITCHER_WIDTHS)
+                    .column_spacing(0)
+                    .style(Style::default().fg(Color::White))
+                    .header(
+                        Row::new(self.state.boxscore.get_pitching_header().iter().copied())
+                            .bold()
+                            .underlined(),
+                    )
+                    .block(Block::default().borders(Borders::NONE)),
+                pitchers,
+                buf,
+            );
+
+            if let Some(paragraph) = game_notes_paragraph {
+                Widget::render(paragraph, game_notes_area, buf);
+            }
+        }
     }
 }

--- a/src/ui/boxscore.rs
+++ b/src/ui/boxscore.rs
@@ -2,7 +2,7 @@ use crate::state::app_state::HomeOrAway;
 use crate::state::boxscore::BoxscoreState;
 use tui::prelude::*;
 use tui::symbols::scrollbar::DOUBLE_VERTICAL;
-use tui::widgets::{Block, Borders, Row, Scrollbar, ScrollbarOrientation, Table};
+use tui::widgets::{Block, Borders, Cell, Row, Scrollbar, ScrollbarOrientation, Table};
 
 const BATTER_WIDTHS: [Constraint; 9] = [
     Constraint::Length(25), // player name
@@ -15,6 +15,7 @@ const BATTER_WIDTHS: [Constraint; 9] = [
     Constraint::Length(4),  // lob
     Constraint::Length(5),  // avg
 ];
+const BATTING_HEADER: &[&str] = &["player", "ab", "r", "h", "rbi", "bb", "k", "lob", "avg"];
 
 const PITCHER_WIDTHS: [Constraint; 9] = [
     Constraint::Length(25), // pitcher name
@@ -27,6 +28,14 @@ const PITCHER_WIDTHS: [Constraint; 9] = [
     Constraint::Length(4),  // hr
     Constraint::Length(5),  // era
 ];
+const PITCHING_HEADER: &[&str] = &["pitcher", "ip", "h", "r", "er", "bb", "k", "hr", "era"];
+
+#[derive(Clone, Copy)]
+struct ScrollParams {
+    scroll_offset: i32,
+    visible_top: i32,
+    visible_bottom: i32,
+}
 
 pub struct TeamBatterBoxscoreWidget<'a> {
     pub active: HomeOrAway,
@@ -34,212 +43,210 @@ pub struct TeamBatterBoxscoreWidget<'a> {
 }
 
 impl Widget for TeamBatterBoxscoreWidget<'_> {
-    fn render(self, area: Rect, buf: &mut Buffer) {
-        self.state
-            .update_scroll_state_for_viewport(area.height, area.width);
+    fn render(mut self, area: Rect, buf: &mut Buffer) {
+        self.state.sync_scrollbar(area.height, area.width);
 
-        let (
-            batting_height,
-            notes_height,
-            pitching_height,
-            game_notes_height,
-            total_content_height,
-        ) = self.state.get_content_heights(self.active);
-
-        let batting_rows = self.state.get_batting_rows(self.active);
-        let batting_notes_paragraph = self.state.get_batting_notes_paragraph(self.active);
-        let pitching_rows = self.state.get_pitching_rows(self.active);
-        let game_notes_paragraph = self.state.get_game_notes_paragraph();
-
-        if total_content_height > area.height {
-            // Create a large virtual area for rendering
-            let virtual_area = Rect {
-                x: area.x,
-                y: 0,
-                width: area.width,
-                height: total_content_height,
-            };
-
-            // Calculate layout in virtual space
-            let [boxscore_area, notes_area, pitchers_area, game_notes_area] = Layout::vertical([
-                Constraint::Length(batting_height),
-                Constraint::Length(notes_height),
-                Constraint::Length(pitching_height),
-                Constraint::Length(game_notes_height),
-            ])
-            .spacing(1)
-            .areas(virtual_area);
-
-            // Adjust areas based on scroll position and clip to visible area
-            let scroll_offset = self.state.scroll as i32;
-            let visible_top = area.y as i32;
-            let visible_bottom = (area.y + area.height) as i32;
-
-            let adjust_area = |area: Rect| -> Option<Rect> {
-                let area_top = area.y as i32 - scroll_offset + visible_top;
-                let area_bottom = area_top + area.height as i32;
-
-                if area_bottom <= visible_top || area_top >= visible_bottom {
-                    return None; // Area is not visible
-                }
-
-                let clipped_top = area_top.max(visible_top);
-                let clipped_bottom = area_bottom.min(visible_bottom);
-                let clipped_height = (clipped_bottom - clipped_top) as u16;
-
-                if clipped_height > 0 {
-                    Some(Rect {
-                        x: area.x,
-                        y: clipped_top as u16,
-                        width: area.width,
-                        height: clipped_height,
-                    })
-                } else {
-                    None
-                }
-            };
-
-            // Render components that are visible
-            if let Some(visible_boxscore) = adjust_area(boxscore_area) {
-                Widget::render(
-                    Table::new(
-                        batting_rows
-                            .into_iter()
-                            .skip(scroll_offset as usize)
-                            .map(Row::new),
-                        BATTER_WIDTHS,
-                    )
-                    .column_spacing(0)
-                    .style(Style::default().fg(Color::White))
-                    .header(
-                        Row::new(self.state.boxscore.get_batting_header().iter().copied())
-                            .bold()
-                            .underlined(),
-                    )
-                    .block(Block::default().borders(Borders::NONE)),
-                    visible_boxscore,
-                    buf,
-                );
-            }
-
-            if let Some(visible_note) = adjust_area(notes_area) {
-                if let Some(paragraph) = batting_notes_paragraph {
-                    let offset = (scroll_offset as u16).saturating_sub(batting_height + 1); // +1 for space
-                    let scrolled = if offset > 0 {
-                        &paragraph.clone().scroll((offset, 0))
-                    } else {
-                        paragraph
-                    };
-                    Widget::render(scrolled, visible_note, buf);
-                }
-            }
-
-            if let Some(visible_pitchers) = adjust_area(pitchers_area) {
-                let offset = (scroll_offset as u16)
-                    .saturating_sub(batting_height + 1)
-                    .saturating_sub(notes_height + 1); // +1 for space
-                Widget::render(
-                    Table::new(
-                        pitching_rows
-                            .into_iter()
-                            .skip(offset as usize)
-                            .map(Row::new),
-                        PITCHER_WIDTHS,
-                    )
-                    .column_spacing(0)
-                    .style(Style::default().fg(Color::White))
-                    .header(
-                        Row::new(self.state.boxscore.get_pitching_header().iter().copied())
-                            .bold()
-                            .underlined(),
-                    )
-                    .block(Block::default().borders(Borders::NONE)),
-                    visible_pitchers,
-                    buf,
-                );
-            }
-
-            if let Some(visible_game_notes) = adjust_area(game_notes_area) {
-                if let Some(paragraph) = game_notes_paragraph {
-                    let offset = (scroll_offset as u16)
-                        .saturating_sub(batting_height + 1)
-                        .saturating_sub(notes_height + 1)
-                        .saturating_sub(pitching_height + 1); // +1 for space
-                    let scrolled = if offset > 0 {
-                        &paragraph.clone().scroll((offset, 0))
-                    } else {
-                        paragraph
-                    };
-
-                    Widget::render(scrolled, visible_game_notes, buf);
-                }
-            }
-
-            // Render scrollbar
-            let scrollbar_area = Rect {
-                x: area.x + area.width + 1, // + 1 to move it over the border
-                y: area.y,
-                width: 1,
-                height: area.height,
-            };
-
-            StatefulWidget::render(
-                Scrollbar::new(ScrollbarOrientation::VerticalRight)
-                    // use the same thumb and track symbol to hide the thumb
-                    .thumb_symbol(DOUBLE_VERTICAL.track)
-                    .track_symbol(Some(DOUBLE_VERTICAL.track))
-                    .begin_symbol(Some("↑"))
-                    .end_symbol(Some("↓")),
-                scrollbar_area,
-                buf,
-                &mut self.state.scroll_state,
-            );
+        if self.state.get_total_content_height() > area.height {
+            self.render_scrollable(area, buf);
         } else {
-            // Render normally without scrolling
-            let [boxscore, note, pitchers, game_notes_area] = Layout::vertical([
-                Constraint::Length(batting_height),
-                Constraint::Length(notes_height),
-                Constraint::Length(pitching_height),
-                Constraint::Fill(1),
-            ])
-            .spacing(1)
-            .areas(area);
+            self.render_static(area, buf);
+        }
+    }
+}
 
+impl TeamBatterBoxscoreWidget<'_> {
+    fn render_scrollable(&mut self, area: Rect, buf: &mut Buffer) {
+        let (batting_height, notes_height, pitching_height, _, total_content_height) =
+            self.state.get_content_heights(self.active);
+
+        // larger area than is visible
+        let virtual_area = Rect {
+            x: area.x,
+            y: 0,
+            width: area.width,
+            height: total_content_height,
+        };
+
+        let [boxscore_area, notes_area, pitchers_area, game_notes_area] =
+            self.get_layout_areas(virtual_area);
+
+        let scroll_offset = self.state.scroll as u16;
+        let params = ScrollParams {
+            scroll_offset: scroll_offset as i32,
+            visible_top: area.y as i32,
+            visible_bottom: (area.y + area.height) as i32,
+        };
+
+        if let Some(visible_boxscore) = adjust_area_for_scroll(boxscore_area, params) {
             Widget::render(
-                Table::new(batting_rows.into_iter().map(Row::new), BATTER_WIDTHS)
-                    .column_spacing(0)
-                    .style(Style::default().fg(Color::White))
-                    .header(
-                        Row::new(self.state.boxscore.get_batting_header().iter().copied())
-                            .bold()
-                            .underlined(),
-                    )
-                    .block(Block::default().borders(Borders::NONE)),
-                boxscore,
+                create_table(
+                    self.state.get_batting_rows(self.active),
+                    &BATTER_WIDTHS,
+                    BATTING_HEADER,
+                    scroll_offset as usize,
+                ),
+                visible_boxscore,
                 buf,
             );
+        }
 
-            if let Some(paragraph) = batting_notes_paragraph {
-                Widget::render(paragraph, note, buf);
-            }
-
-            Widget::render(
-                Table::new(pitching_rows.into_iter().map(Row::new), PITCHER_WIDTHS)
-                    .column_spacing(0)
-                    .style(Style::default().fg(Color::White))
-                    .header(
-                        Row::new(self.state.boxscore.get_pitching_header().iter().copied())
-                            .bold()
-                            .underlined(),
-                    )
-                    .block(Block::default().borders(Borders::NONE)),
-                pitchers,
-                buf,
-            );
-
-            if let Some(paragraph) = game_notes_paragraph {
-                Widget::render(paragraph, game_notes_area, buf);
+        if let Some(visible_note) = adjust_area_for_scroll(notes_area, params) {
+            if let Some(paragraph) = self.state.get_batting_notes_paragraph(self.active) {
+                let offset = scroll_offset.saturating_sub(batting_height + 1); // +1 for space
+                render_paragraph_with_scroll(paragraph, offset, visible_note, buf);
             }
         }
+
+        if let Some(visible_pitchers) = adjust_area_for_scroll(pitchers_area, params) {
+            let offset = scroll_offset
+                .saturating_sub(batting_height + 1)
+                .saturating_sub(notes_height + 1); // +1 for space
+            Widget::render(
+                create_table(
+                    self.state.get_pitching_rows(self.active),
+                    &PITCHER_WIDTHS,
+                    PITCHING_HEADER,
+                    offset as usize,
+                ),
+                visible_pitchers,
+                buf,
+            );
+        }
+
+        if let Some(visible_game_notes) = adjust_area_for_scroll(game_notes_area, params) {
+            if let Some(paragraph) = self.state.get_game_notes_paragraph() {
+                let offset = scroll_offset
+                    .saturating_sub(batting_height + 1)
+                    .saturating_sub(notes_height + 1)
+                    .saturating_sub(pitching_height + 1); // +1 for space
+                render_paragraph_with_scroll(paragraph, offset, visible_game_notes, buf);
+            }
+        }
+
+        self.render_scrollbar(area, buf);
+    }
+
+    fn render_static(&mut self, area: Rect, buf: &mut Buffer) {
+        let [boxscore, note, pitchers, game_notes_area] = self.get_layout_areas(area);
+
+        Widget::render(
+            create_table(
+                self.state.get_batting_rows(self.active),
+                &BATTER_WIDTHS,
+                BATTING_HEADER,
+                0,
+            ),
+            boxscore,
+            buf,
+        );
+
+        if let Some(paragraph) = self.state.get_batting_notes_paragraph(self.active) {
+            Widget::render(paragraph, note, buf);
+        }
+
+        Widget::render(
+            create_table(
+                self.state.get_pitching_rows(self.active),
+                &PITCHER_WIDTHS,
+                PITCHING_HEADER,
+                0,
+            ),
+            pitchers,
+            buf,
+        );
+
+        if let Some(paragraph) = self.state.get_game_notes_paragraph() {
+            Widget::render(paragraph, game_notes_area, buf);
+        }
+    }
+
+    fn render_scrollbar(&mut self, area: Rect, buf: &mut Buffer) {
+        let scrollbar_area = Rect {
+            x: area.x + area.width + 1, // + 1 to move it over the border
+            y: area.y,
+            width: 1,
+            height: area.height,
+        };
+        StatefulWidget::render(
+            Scrollbar::new(ScrollbarOrientation::VerticalRight)
+                // use the same thumb and track symbol to hide the thumb
+                .thumb_symbol(DOUBLE_VERTICAL.track)
+                .track_symbol(Some(DOUBLE_VERTICAL.track))
+                .begin_symbol(Some("↑"))
+                .end_symbol(Some("↓")),
+            scrollbar_area,
+            buf,
+            &mut self.state.scroll_state,
+        );
+    }
+
+    fn get_layout_areas(&mut self, area: Rect) -> [Rect; 4] {
+        let (batting_height, notes_height, pitching_height, game_notes_height, _) =
+            self.state.get_content_heights(self.active);
+
+        Layout::vertical([
+            Constraint::Length(batting_height),
+            Constraint::Length(notes_height),
+            Constraint::Length(pitching_height),
+            Constraint::Length(game_notes_height),
+        ])
+        .spacing(1)
+        .areas(area)
+    }
+}
+
+fn create_table<'a, I, R>(
+    rows: I,
+    widths: &[Constraint],
+    header: &'static [&'static str],
+    skip_rows: usize,
+) -> Table<'a>
+where
+    I: IntoIterator<Item = R>,
+    R: IntoIterator<Item = Cell<'a>>,
+{
+    Table::new(rows.into_iter().skip(skip_rows).map(Row::new), widths)
+        .column_spacing(0)
+        .style(Style::default().fg(Color::White))
+        .header(Row::new(header.iter().copied()).bold().underlined())
+        .block(Block::default().borders(Borders::NONE))
+}
+
+fn render_paragraph_with_scroll(
+    paragraph: &tui::widgets::Paragraph<'static>,
+    scroll_offset: u16,
+    area: Rect,
+    buf: &mut Buffer,
+) {
+    if scroll_offset > 0 {
+        let scrolled = paragraph.clone().scroll((scroll_offset, 0));
+        Widget::render(scrolled, area, buf);
+    } else {
+        Widget::render(paragraph, area, buf);
+    };
+}
+
+/// Adjust areas based on scroll position and clip to visible area
+fn adjust_area_for_scroll(area: Rect, params: ScrollParams) -> Option<Rect> {
+    let area_top = area.y as i32 - params.scroll_offset + params.visible_top;
+    let area_bottom = area_top + area.height as i32;
+
+    if area_bottom <= params.visible_top || area_top >= params.visible_bottom {
+        return None; // Area is not visible
+    }
+
+    let clipped_top = area_top.max(params.visible_top);
+    let clipped_bottom = area_bottom.min(params.visible_bottom);
+    let clipped_height = clipped_bottom - clipped_top;
+
+    if clipped_height > 0 {
+        Some(Rect {
+            x: area.x,
+            y: clipped_top as u16,
+            width: area.width,
+            height: clipped_height as u16,
+        })
+    } else {
+        None
     }
 }

--- a/src/ui/gameday/gameday_widget.rs
+++ b/src/ui/gameday/gameday_widget.rs
@@ -1,6 +1,7 @@
 use crate::app::MenuItem;
 use crate::draw;
 use crate::state::app_state::HomeOrAway;
+use crate::state::boxscore::BoxscoreState;
 use crate::state::gameday::GamedayState;
 use crate::ui::boxscore::TeamBatterBoxscoreWidget;
 use crate::ui::gameday::at_bat::AtBatWidget;
@@ -13,6 +14,7 @@ use tui::prelude::{Buffer, Color, Rect, Widget};
 
 pub struct GamedayWidget<'a> {
     pub state: &'a GamedayState,
+    pub boxscore_state: &'a mut BoxscoreState,
     pub active: HomeOrAway,
 }
 
@@ -36,7 +38,7 @@ impl Widget for GamedayWidget<'_> {
 
             let boxscore_widget = TeamBatterBoxscoreWidget {
                 active: self.active,
-                boxscore: &self.state.game.boxscore,
+                state: self.boxscore_state,
             };
             Widget::render(boxscore_widget, chunks[1], buf);
         }

--- a/src/ui/help.rs
+++ b/src/ui/help.rs
@@ -5,38 +5,42 @@ use tui::prelude::{Buffer, Modifier, Rect, Style};
 use tui::widgets::{Paragraph, Row, Table, Widget};
 
 const HEADER: &[&str; 2] = &["Description", "Key"];
-pub const DOCS: &[&[&str; 2]; 33] = &[
+pub const DOCS: &[&[&str; 2]; 37] = &[
     &["Exit help", "Esc"],
     &["Quit", "q"],
     &["Full screen", "f"],
     &["Scoreboard", "1"],
-    &["Move down", "j"],
-    &["Move up", "k"],
+    &["Move down", "j/↓"],
+    &["Move up", "k/↑"],
     &["Select date", ":"],
     &["Switch boxscore team", "h/a"],
+    &["Scroll boxscore down", "Shift + j/↓"],
+    &["Scroll boxscore up", "Shift + k/↑"],
     &["Toggle win probability", "w"],
     &["Gameday", "2"],
     &["Toggle game info", "i"],
     &["Toggle pitches", "p"],
     &["Toggle boxscore", "b"],
     &["Switch boxscore team", "h/a"],
+    &["Scroll boxscore down", "Shift + j/↓"],
+    &["Scroll boxscore up", "Shift + k/↑"],
     &["Toggle win probability", "w"],
-    &["Move down at bat", "j"],
-    &["Move up at bat", "k"],
+    &["Move down at bat", "j/↓"],
+    &["Move up at bat", "k/↑"],
     &["Go to live at bat", "l"],
     &["Go to first at bat", "s"],
     &["Stats", "3"],
     &["Switch hitting/pitching", "h/p"],
     &["Switch team/player", "t/l"],
-    &["Move down", "j"],
-    &["Move up", "k"],
+    &["Move down", "j/↓"],
+    &["Move up", "k/↑"],
     &["Toggle stat", "Enter"],
     &["Sort by stat", "s"],
     &["Select date", ":"],
     &["Toggle stat selection", "o"],
     &["Standings", "4"],
-    &["Move down", "j"],
-    &["Move up", "k"],
+    &["Move down", "j/↓"],
+    &["Move up", "k/↑"],
     &["Select date", ":"],
     &["View team info", "Enter"],
 ];
@@ -67,12 +71,13 @@ impl Widget for HelpWidget {
             .bottom_margin(0)
             .style(header_style);
 
-        let docs = DOCS.iter().map(|d| format_row(d)).collect::<Vec<HelpRow>>();
-
-        let rows = docs.iter().map(|item| match item.is_header {
-            true => Row::new(item.text.clone()).style(header_style),
-            false => Row::new(item.text.clone()).style(help_menu_style),
-        });
+        let rows = DOCS
+            .iter()
+            .map(|d| format_row(d))
+            .map(|item| match item.is_header {
+                true => Row::new(item.text).style(header_style),
+                false => Row::new(item.text).style(help_menu_style),
+            });
 
         let [table, banner] = Layout::horizontal([Constraint::Length(50), Constraint::Length(15)])
             .flex(Flex::Legacy)


### PR DESCRIPTION
If the boxscore is too long to fit in the terminal a scrollbar will show up on the right side. Holding `Shift` and using `j/k` or `up/down` will scroll it

![scrollable-boxscore](https://github.com/user-attachments/assets/4357683c-62fc-4179-a056-8afa920947b6)
