### PR TITLE
Publish mlbt image to ghcr

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,3 +34,14 @@ jobs:
 
       - name: Run cargo test
         run: cargo test --all-features --all-targets --workspace --locked
+
+  test-docker-build:
+    name: Verify docker image can build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Sources
+        uses: actions/checkout@v3
+
+      - name: Build Image
+        run: |
+          docker build .

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,27 @@
+name: Publish Docker Image to GHCR
+
+on:
+  push:
+    branches: [ main ]
+
+jobs:
+  publish-docker-image:
+    runs-on: ubuntu-latest
+    permissions:
+     contents: read
+     packages: write
+    steps:
+      - name: Checkout Sources
+        uses: actions/checkout@v3
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{github.actor}}
+          password: ${{secrets.GITHUB_TOKEN}}
+
+      - name: Build and Push Image
+        run: |
+          docker build . --tag ghcr.io/mlb-rs/mlbt:latest
+          docker push ghcr.io/mlb-rs/mlbt:latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,7 @@ on:
       - "v*.*.*"
 
 jobs:
-  publish:
+  publish-platform-artifacts:
     name: Publishing for ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     strategy:
@@ -89,3 +89,31 @@ jobs:
             target/${{ matrix.target }}/release/mlbt-${{ matrix.artifact_prefix }}.sha256
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  publish-docker-image:
+    runs-on: ubuntu-latest
+    permissions:
+     contents: read
+     packages: write
+    steps:
+      - name: Checkout Sources
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Get tag
+        run: |
+          git fetch --tags --force
+          echo "TAG=$(git describe --tags --abbrev=0)" >> $GITHUB_ENV
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{github.actor}}
+          password: ${{secrets.GITHUB_TOKEN}}
+
+      - name: Build and Push Image
+        run: |
+          docker build . --tag ghcr.io/mlb-rs/mlbt:$TAG
+          docker push ghcr.io/mlb-rs/mlbt:$TAG

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,8 @@
 FROM rust:1.88 AS builder
+LABEL org.opencontainers.image.source=https://github.com/mlb-rs/mlbt
+LABEL org.opencontainers.image.description="A terminal user interface for the MLB Statcast API, written in Rust."
+LABEL org.opencontainers.image.licenses=MIT
+
 WORKDIR /usr/src/mlbt
 COPY . .
 RUN cargo build --release

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Check scores, standings, and stats. Even watch a live game using Gameday!
     - [Homebrew](#homebrew)
     - [Binaries](#binaries)
     - [Cargo](#cargo)
+    - [Docker](#docker)
 - [Features](#features)
 - [Usage](#usage)
     - [Scoreboard](#scoreboard)
@@ -80,7 +81,18 @@ cargo install mlbt --path .
 
 ### Docker
 
-Build image with:
+`mlbt` [publishes docker images on ghcr](https://github.com/mlb-rs/mlbt/pkgs/container/mlbt).
+```bash
+docker run -it --rm --name mlbt ghcr.io/mlb-rs/mlbt
+```
+
+`mlbt` follows [semver](https://semver.org/) practices.
+You can execute individual releases explicitly.
+```bash
+docker run -it --rm --name mlbt ghcr.io/mlb-rs/mlbt:v0.0.18
+```
+
+Alternately build the `mlbt` image with:
 
 ```bash
 docker build -t mlbt .


### PR DESCRIPTION
Hello,

Please consider this PR. You can see how it works on my fork, https://github.com/isaacnboyd/mlbt/pkgs/container/mlbt.  
This will publish images to `ghcr.io/andschneider/mlbt`. This requires no action by yourself, it will use your `GITHUB_TOKEN`,
much like you already are doing with `softprops/action-gh-release@v1`. This adds a "Packages" section to the right hand
column as you can see on my fork: https://github.com/isaacnboyd/mlbt.

Let me know if you have questions and thanks for all the work you've done on this project recently!

=================================================================================
This commit includes actions to publish images to the github container registry on both pushes to the main branch and tagged releases. The labels, most importantly the org.opencontainers.image.source is a requirement for public access to the built image.