### PR TITLE
Update score format for non pitch events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+## Fixed
+
+- Format the score changes on non pitch events (e.g. pass ball) the same as an
+  at bat event: [PR 86](https://github.com/mlb-rs/mlbt/pull/86).
+
 ## [0.0.18] - 2025-07-19
 
 ## Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1066,7 +1066,7 @@ dependencies = [
 
 [[package]]
 name = "mlbt"
-version = "0.0.18"
+version = "0.0.19-alpha.1"
 dependencies = [
  "anyhow",
  "better-panic",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mlbt"
-version = "0.0.18"
+version = "0.0.19-alpha.1"
 authors = ["Andrew Schneider <andjschneider@gmail.com>"]
 edition = "2024"
 license = "MIT"

--- a/src/ui/gameday/at_bat.rs
+++ b/src/ui/gameday/at_bat.rs
@@ -78,7 +78,13 @@ impl Widget for AtBatWidget<'_> {
             .pitch_events
             .iter()
             .rev() // reverse so that the last event is at the top
-            .filter_map(|event| event.as_lines(false))
+            .filter_map(|event| {
+                event.as_lines(
+                    false,
+                    self.game.home_team.abbreviation,
+                    self.game.away_team.abbreviation,
+                )
+            })
             .flatten()
             .collect();
 

--- a/src/ui/gameday/plays.rs
+++ b/src/ui/gameday/plays.rs
@@ -145,14 +145,27 @@ fn format_score<'a>(
     away_team_abbreviation: &'static str,
 ) -> Span<'a> {
     if play.is_scoring_play {
-        Span::raw(format!(
-            " [{} {}, {} {}]",
-            away_team_abbreviation, play.away_score, home_team_abbreviation, play.home_score
-        ))
-        .bold()
+        build_scoring_span(
+            play.home_score,
+            home_team_abbreviation,
+            play.away_score,
+            away_team_abbreviation,
+        )
     } else {
         Span::raw("")
     }
+}
+
+pub fn build_scoring_span(
+    home_score: u8,
+    home_team_abbreviation: &'static str,
+    away_score: u8,
+    away_team_abbreviation: &'static str,
+) -> Span<'static> {
+    Span::raw(format!(
+        " [{away_team_abbreviation} {away_score}, {home_team_abbreviation} {home_score}]"
+    ))
+    .bold()
 }
 
 /// If an out was made display it.


### PR DESCRIPTION
The score formatting for non-pitch events (things that happened during an at bat without a pitch thrown) wasn't updated to the newest format

| before | after |
| -- | -- |
| <img width="491" height="182" alt="Screenshot 2025-07-27 at 1 33 05 PM" src="https://github.com/user-attachments/assets/31ea9f92-c278-417d-99c4-1098c1939f38" /> |  <img width="488" height="180" alt="Screenshot 2025-07-27 at 1 32 55 PM" src="https://github.com/user-attachments/assets/e11e3e87-b9e9-4d20-9ac3-f9cca4774f59" /> | 