### PR TITLE
Add toggleable color highlights for stats (AVG, win%, zero dimming)

### DIFF
--- a/src/components/boxscore.rs
+++ b/src/components/boxscore.rs
@@ -10,6 +10,18 @@ use tui::widgets::Cell;
 
 const SECONDARY_COLOR: Color = Color::DarkGray;
 
+pub(crate) fn avg_color(avg: &str) -> Option<Color> {
+    avg.parse::<f64>().ok().map(|v| {
+        if v >= 0.300 {
+            Color::Green
+        } else if v < 0.100 {
+            Color::Red
+        } else {
+            Color::White
+        }
+    })
+}
+
 #[derive(Default)]
 pub struct Boxscore {
     home_batting: Vec<BatterBoxscore>,
@@ -131,7 +143,8 @@ impl BatterBoxscore {
             Cell::from(self.walks.to_string()).fg(color),
             Cell::from(self.strike_outs.to_string()).fg(color),
             Cell::from(self.left_on.to_string()).fg(color),
-            Cell::from(self.batting_average.to_string()).fg(color),
+            Cell::from(self.batting_average.to_string())
+                .fg(avg_color(&self.batting_average).unwrap_or(color)),
         ]
     }
 }

--- a/src/components/boxscore.rs
+++ b/src/components/boxscore.rs
@@ -10,9 +10,23 @@ use tui::widgets::Cell;
 
 const SECONDARY_COLOR: Color = Color::DarkGray;
 
+pub(crate) fn win_pct_color(pct: &str) -> Option<Color> {
+    pct.parse::<f64>().ok().map(|v| {
+        if v == 0.0 {
+            Color::DarkGray
+        } else if v >= 0.500 {
+            Color::Green
+        } else {
+            Color::Red
+        }
+    })
+}
+
 pub(crate) fn avg_color(avg: &str) -> Option<Color> {
     avg.parse::<f64>().ok().map(|v| {
-        if v >= 0.300 {
+        if v == 0.0 {
+            Color::DarkGray
+        } else if v >= 0.300 {
             Color::Green
         } else if v < 0.100 {
             Color::Red
@@ -113,7 +127,7 @@ impl BatterBoxscore {
         }
     }
 
-    pub fn to_cells(&self) -> Vec<Cell<'_>> {
+    pub fn to_cells(&self, show_colors: bool) -> Vec<Cell<'_>> {
         let note = self.note.as_deref().unwrap_or_default();
         let prefix = match self.is_substitute {
             true => "  ".to_string(),
@@ -134,17 +148,23 @@ impl BatterBoxscore {
             )
         };
 
+        let avg_col = if show_colors {
+            avg_color(&self.batting_average).unwrap_or(color)
+        } else {
+            color
+        };
+        let dim = |v: u16| if show_colors && v == 0 { Color::DarkGray } else { color };
+
         vec![
             Cell::from(name),
-            Cell::from(self.at_bats.to_string()).fg(color),
-            Cell::from(self.runs.to_string()).fg(color),
-            Cell::from(self.hits.to_string()).fg(color),
-            Cell::from(self.rbis.to_string()).fg(color),
-            Cell::from(self.walks.to_string()).fg(color),
-            Cell::from(self.strike_outs.to_string()).fg(color),
-            Cell::from(self.left_on.to_string()).fg(color),
-            Cell::from(self.batting_average.to_string())
-                .fg(avg_color(&self.batting_average).unwrap_or(color)),
+            Cell::from(self.at_bats.to_string()).fg(dim(self.at_bats)),
+            Cell::from(self.runs.to_string()).fg(dim(self.runs)),
+            Cell::from(self.hits.to_string()).fg(dim(self.hits)),
+            Cell::from(self.rbis.to_string()).fg(dim(self.rbis)),
+            Cell::from(self.walks.to_string()).fg(dim(self.walks)),
+            Cell::from(self.strike_outs.to_string()).fg(dim(self.strike_outs)),
+            Cell::from(self.left_on.to_string()).fg(dim(self.left_on)),
+            Cell::from(self.batting_average.to_string()).fg(avg_col),
         ]
     }
 }
@@ -182,7 +202,7 @@ impl PitcherBoxscore {
         }
     }
 
-    pub fn to_cells(&self) -> Vec<Cell<'_>> {
+    pub fn to_cells(&self, show_colors: bool) -> Vec<Cell<'_>> {
         let note = self.note.as_deref().unwrap_or_default();
         let (name, color) = if self.name == "Totals" {
             (
@@ -201,15 +221,17 @@ impl PitcherBoxscore {
             (self.name.clone().into(), Color::White)
         };
 
+        let dim = |v: u8| if show_colors && v == 0 { Color::DarkGray } else { color };
+
         vec![
             Cell::from(name),
             Cell::from(self.innings_pitched.clone()).fg(color),
-            Cell::from(self.hits.to_string()).fg(color),
-            Cell::from(self.runs.to_string()).fg(color),
-            Cell::from(self.earned_runs.to_string()).fg(color),
-            Cell::from(self.walks.to_string()).fg(color),
-            Cell::from(self.strikeouts.to_string()).fg(color),
-            Cell::from(self.home_runs.to_string()).fg(color),
+            Cell::from(self.hits.to_string()).fg(dim(self.hits)),
+            Cell::from(self.runs.to_string()).fg(dim(self.runs)),
+            Cell::from(self.earned_runs.to_string()).fg(dim(self.earned_runs)),
+            Cell::from(self.walks.to_string()).fg(dim(self.walks)),
+            Cell::from(self.strikeouts.to_string()).fg(dim(self.strikeouts)),
+            Cell::from(self.home_runs.to_string()).fg(dim(self.home_runs)),
             Cell::from(self.era.clone()).fg(color),
         ]
     }
@@ -370,10 +392,11 @@ impl Boxscore {
     pub fn to_batting_table_rows<'a>(
         &'a self,
         active: HomeOrAway,
-    ) -> impl Iterator<Item = Vec<Cell<'a>>> + 'a {
+        show_colors: bool,
+    ) -> Box<dyn Iterator<Item = Vec<Cell<'a>>> + 'a> {
         match active {
-            HomeOrAway::Home => self.home_batting.iter().map(BatterBoxscore::to_cells),
-            HomeOrAway::Away => self.away_batting.iter().map(BatterBoxscore::to_cells),
+            HomeOrAway::Home => Box::new(self.home_batting.iter().map(move |b| b.to_cells(show_colors))),
+            HomeOrAway::Away => Box::new(self.away_batting.iter().map(move |b| b.to_cells(show_colors))),
         }
     }
 
@@ -387,10 +410,11 @@ impl Boxscore {
     pub fn to_pitching_table_rows<'a>(
         &'a self,
         active: HomeOrAway,
-    ) -> impl Iterator<Item = Vec<Cell<'a>>> + 'a {
+        show_colors: bool,
+    ) -> Box<dyn Iterator<Item = Vec<Cell<'a>>> + 'a> {
         match active {
-            HomeOrAway::Home => self.home_pitching.iter().map(PitcherBoxscore::to_cells),
-            HomeOrAway::Away => self.away_pitching.iter().map(PitcherBoxscore::to_cells),
+            HomeOrAway::Home => Box::new(self.home_pitching.iter().map(move |p| p.to_cells(show_colors))),
+            HomeOrAway::Away => Box::new(self.away_pitching.iter().map(move |p| p.to_cells(show_colors))),
         }
     }
 

--- a/src/components/linescore.rs
+++ b/src/components/linescore.rs
@@ -2,6 +2,7 @@ use mlbt_api::live::LiveResponse;
 
 use crate::components::standings::Team;
 use crate::state::app_state::HomeOrAway;
+use tui::prelude::Stylize;
 use tui::style::{Color, Modifier, Style};
 use tui::text::Span;
 use tui::widgets::Cell;
@@ -91,7 +92,7 @@ impl LineScoreLine {
         line
     }
 
-    pub fn create_score_vec(&self, active: HomeOrAway) -> Vec<Cell<'_>> {
+    pub fn create_score_vec(&self, active: HomeOrAway, show_colors: bool) -> Vec<Cell<'_>> {
         let mut row = vec![];
         // Display a blue background if the team is active
         let team = match active == self.team {
@@ -103,10 +104,18 @@ impl LineScoreLine {
         };
         row.push(Cell::from(team));
 
+        let dim = |v: u8| {
+            if show_colors && v == 0 {
+                Color::DarkGray
+            } else {
+                Color::White
+            }
+        };
+
         let scores = self
             .inning_score
             .iter()
-            .map(|s| Cell::from(s.to_string()))
+            .map(|&s| Cell::from(s.to_string()).fg(dim(s)))
             .collect::<Vec<_>>();
         row.extend(scores);
 
@@ -118,10 +127,10 @@ impl LineScoreLine {
         // add the runs, hits, and errors to the end
         row.push(Cell::from(Span::styled(
             self.runs.to_string(),
-            Style::default().add_modifier(Modifier::BOLD),
+            Style::default().fg(dim(self.runs)).add_modifier(Modifier::BOLD),
         )));
-        row.push(Cell::from(self.hits.to_string()));
-        row.push(Cell::from(self.errors.to_string()));
+        row.push(Cell::from(self.hits.to_string()).fg(dim(self.hits)));
+        row.push(Cell::from(self.errors.to_string()).fg(dim(self.errors)));
         row
     }
 

--- a/src/components/standings.rs
+++ b/src/components/standings.rs
@@ -1,3 +1,4 @@
+use crate::components::boxscore::win_pct_color;
 use crate::components::constants::{DIVISION_ORDERS, DIVISIONS, lookup_team, lookup_team_by_id};
 use crate::components::date_selector::DateSelector;
 use crate::state::team_page::TeamPageState;
@@ -467,17 +468,22 @@ impl Standing {
         }
     }
 
-    pub fn to_cells(&self) -> Vec<Cell<'_>> {
+    pub fn to_cells(&self, show_colors: bool) -> Vec<Cell<'_>> {
         let (prefix, rdiff_color) = match self.run_differential.signum() {
             1 => ("+", Color::Green),
             -1 => ("", Color::Red),
             _ => ("", Color::White),
         };
+        let pct_color = if show_colors {
+            win_pct_color(&self.winning_percentage).unwrap_or(Color::White)
+        } else {
+            Color::White
+        };
         vec![
             self.team.name.to_string().into(),
             self.wins.to_string().into(),
             self.losses.to_string().into(),
-            self.winning_percentage.clone().into(),
+            Cell::from(self.winning_percentage.clone()).fg(pct_color),
             self.games_back.clone().into(),
             self.wild_card_games_back.clone().into(),
             self.last_10.clone().into(),

--- a/src/components/stats/player_profile.rs
+++ b/src/components/stats/player_profile.rs
@@ -149,7 +149,7 @@ impl PlayerProfile {
         bio
     }
 
-    fn split_to_cells(split: &Split, show_year: bool) -> Vec<Cell<'_>> {
+    fn split_to_cells(split: &Split, show_year: bool, show_colors: bool) -> Vec<Cell<'_>> {
         let mut cells = Vec::new();
 
         if show_year {
@@ -167,7 +167,11 @@ impl PlayerProfile {
                 cells.extend([
                     s.games_played.to_string().into(),
                     s.at_bats.to_string().into(),
-                    Cell::from(s.avg.as_str()).fg(avg_color(s.avg.as_str()).unwrap_or(Color::White)),
+                    if show_colors {
+                        Cell::from(s.avg.as_str()).fg(avg_color(s.avg.as_str()).unwrap_or(Color::White))
+                    } else {
+                        s.avg.as_str().into()
+                    },
                     s.obp.as_str().into(),
                     s.slg.as_str().into(),
                     s.ops.as_str().into(),
@@ -205,7 +209,7 @@ impl PlayerProfile {
         cells
     }
 
-    fn game_log_cells(split: &Split) -> Vec<Cell<'_>> {
+    fn game_log_cells(split: &Split, show_colors: bool) -> Vec<Cell<'_>> {
         let date = split.date.map_display_or(|d| format_date(d), "");
         let opp = split
             .opponent
@@ -238,7 +242,11 @@ impl PlayerProfile {
                     s.strike_outs.to_string().into(),
                     s.stolen_bases.to_string().into(),
                     s.caught_stealing.to_string().into(),
-                    Cell::from(s.avg.as_str()).fg(avg_color(s.avg.as_str()).unwrap_or(Color::White)),
+                    if show_colors {
+                        Cell::from(s.avg.as_str()).fg(avg_color(s.avg.as_str()).unwrap_or(Color::White))
+                    } else {
+                        s.avg.as_str().into()
+                    },
                 ]);
             }
             StatSplit::Pitching(s) => {
@@ -257,9 +265,9 @@ impl PlayerProfile {
         cells
     }
 
-    pub fn career_total_cells(split: &Split) -> Vec<Cell<'_>> {
+    pub fn career_total_cells(split: &Split, show_colors: bool) -> Vec<Cell<'_>> {
         let mut cells = vec!["".into(), "TOT".into()];
-        cells.extend(Self::split_to_cells(split, false));
+        cells.extend(Self::split_to_cells(split, false, show_colors));
         cells
     }
 
@@ -267,6 +275,7 @@ impl PlayerProfile {
     pub fn build_stat_rows(
         splits: &[Split],
         show_year: bool,
+        show_colors: bool,
     ) -> Option<(Row<'_>, Vec<Constraint>, Vec<Row<'_>>)> {
         let first = splits.first()?;
         let headers = if matches!(&first.stat, StatSplit::Hitting(_)) {
@@ -291,7 +300,7 @@ impl PlayerProfile {
 
         let rows = splits
             .iter()
-            .map(|split| Row::new(Self::split_to_cells(split, show_year)))
+            .map(|split| Row::new(Self::split_to_cells(split, show_year, show_colors)))
             .collect();
 
         Some((header, widths, rows))
@@ -300,6 +309,7 @@ impl PlayerProfile {
     /// Build header row, column widths, and data rows for the game log table.
     pub fn build_game_log_rows(
         splits: &[Split],
+        show_colors: bool,
     ) -> Option<(Row<'_>, Vec<Constraint>, Vec<Row<'_>>)> {
         let first = splits.first()?;
         let headers = if matches!(&first.stat, StatSplit::Hitting(_)) {
@@ -317,7 +327,7 @@ impl PlayerProfile {
         let rows = splits
             .iter()
             .rev()
-            .map(|split| Row::new(Self::game_log_cells(split)))
+            .map(|split| Row::new(Self::game_log_cells(split, show_colors)))
             .collect();
 
         Some((header, widths, rows))
@@ -327,6 +337,7 @@ impl PlayerProfile {
     pub fn build_splits_rows(
         recent_splits: &[RecentSplit],
         is_hitting: bool,
+        show_colors: bool,
     ) -> Option<(Row<'_>, Vec<Constraint>, Vec<Row<'_>>)> {
         if !recent_splits.iter().any(|s| s.stat.is_some()) {
             return None;
@@ -359,7 +370,11 @@ impl PlayerProfile {
                             s.bb.to_string().into(),
                             s.so.to_string().into(),
                             s.sb.to_string().into(),
-                            Cell::from(s.avg.as_str()).fg(avg_color(s.avg.as_str()).unwrap_or(Color::White)),
+                            if show_colors {
+                                Cell::from(s.avg.as_str()).fg(avg_color(s.avg.as_str()).unwrap_or(Color::White))
+                            } else {
+                                s.avg.as_str().into()
+                            },
                             s.obp.as_str().into(),
                             s.slg.as_str().into(),
                         ]);

--- a/src/components/stats/player_profile.rs
+++ b/src/components/stats/player_profile.rs
@@ -1,3 +1,4 @@
+use crate::components::boxscore::avg_color;
 use crate::components::constants::{lookup_team, lookup_team_by_id};
 use crate::components::standings::Team;
 use crate::components::stats::splits::{RecentSplit, RecentStats, StatSplits};
@@ -5,7 +6,8 @@ use crate::components::util::{OptionDisplayExt, OptionMapDisplayExt, format_date
 use mlbt_api::player::PersonFull;
 use mlbt_api::stats::{Split, StatSplit};
 use tui::layout::Constraint;
-use tui::prelude::{Line, Modifier, Style};
+use tui::prelude::{Line, Modifier, Style, Stylize};
+use tui::style::Color;
 use tui::widgets::{Cell, Row};
 
 const STAT_COL_WIDTH: u16 = 6;
@@ -165,7 +167,7 @@ impl PlayerProfile {
                 cells.extend([
                     s.games_played.to_string().into(),
                     s.at_bats.to_string().into(),
-                    s.avg.as_str().into(),
+                    Cell::from(s.avg.as_str()).fg(avg_color(s.avg.as_str()).unwrap_or(Color::White)),
                     s.obp.as_str().into(),
                     s.slg.as_str().into(),
                     s.ops.as_str().into(),
@@ -236,7 +238,7 @@ impl PlayerProfile {
                     s.strike_outs.to_string().into(),
                     s.stolen_bases.to_string().into(),
                     s.caught_stealing.to_string().into(),
-                    s.avg.as_str().into(),
+                    Cell::from(s.avg.as_str()).fg(avg_color(s.avg.as_str()).unwrap_or(Color::White)),
                 ]);
             }
             StatSplit::Pitching(s) => {
@@ -357,7 +359,7 @@ impl PlayerProfile {
                             s.bb.to_string().into(),
                             s.so.to_string().into(),
                             s.sb.to_string().into(),
-                            s.avg.as_str().into(),
+                            Cell::from(s.avg.as_str()).fg(avg_color(s.avg.as_str()).unwrap_or(Color::White)),
                             s.obp.as_str().into(),
                             s.slg.as_str().into(),
                         ]);

--- a/src/draw.rs
+++ b/src/draw.rs
@@ -186,6 +186,7 @@ fn draw_linescore_boxscore(f: &mut Frame, rect: Rect, app: &mut App) {
         LineScoreWidget {
             active: app.state.box_score.active_team,
             linescore: &app.state.gameday.game.linescore,
+            show_colors: app.state.show_colors,
         },
         chunks[0],
     );
@@ -193,6 +194,7 @@ fn draw_linescore_boxscore(f: &mut Frame, rect: Rect, app: &mut App) {
         TeamBatterBoxscoreWidget {
             active: app.state.box_score.active_team,
             state: &mut app.state.box_score,
+            show_colors: app.state.show_colors,
         },
         chunks[1],
     );
@@ -212,6 +214,7 @@ fn draw_gameday(f: &mut Frame, rect: Rect, app: &mut App) {
             active: app.state.box_score.active_team,
             state: &app.state.gameday,
             boxscore_state: &mut app.state.box_score,
+            show_colors: app.state.show_colors,
         },
         rect,
     );
@@ -220,14 +223,14 @@ fn draw_gameday(f: &mut Frame, rect: Rect, app: &mut App) {
 fn draw_stats(f: &mut Frame, rect: Rect, app: &mut App) {
     if let Some(tp) = &mut app.state.stats.team_page {
         if let Some(profile) = &mut tp.player_profile {
-            PlayerProfileWidget { state: profile }.render(rect, f.buffer_mut());
+            PlayerProfileWidget { state: profile, show_colors: app.state.show_colors }.render(rect, f.buffer_mut());
             return;
         }
         TeamPageWidget { state: tp }.render(rect, f.buffer_mut());
         return;
     }
     if let Some(profile) = &mut app.state.stats.player_profile {
-        PlayerProfileWidget { state: profile }.render(rect, f.buffer_mut());
+        PlayerProfileWidget { state: profile, show_colors: app.state.show_colors }.render(rect, f.buffer_mut());
         return;
     }
 
@@ -257,7 +260,7 @@ fn draw_stats(f: &mut Frame, rect: Rect, app: &mut App) {
     // of space for columns. If I didn't, you could select columns that would be covered by the
     // options pane, but then when its disabled would become visible.
     app.state.stats.table.trim_columns(data_table_area.width);
-    f.render_stateful_widget(StatsDataWidget {}, data_table_area, &mut app.state.stats);
+    f.render_stateful_widget(StatsDataWidget { show_colors: app.state.show_colors }, data_table_area, &mut app.state.stats);
 
     if let Some(options_area) = options_area {
         f.render_stateful_widget(StatsOptionsWidget {}, options_area, &mut app.state.stats);
@@ -290,13 +293,13 @@ fn draw_stats(f: &mut Frame, rect: Rect, app: &mut App) {
 fn draw_standings(f: &mut Frame, rect: Rect, app: &mut App) {
     if let Some(tp) = &mut app.state.standings.team_page {
         if let Some(profile) = &mut tp.player_profile {
-            PlayerProfileWidget { state: profile }.render(rect, f.buffer_mut());
+            PlayerProfileWidget { state: profile, show_colors: app.state.show_colors }.render(rect, f.buffer_mut());
             return;
         }
         TeamPageWidget { state: tp }.render(rect, f.buffer_mut());
         return;
     }
-    f.render_stateful_widget(StandingsWidget {}, rect, &mut app.state.standings);
+    f.render_stateful_widget(StandingsWidget { show_colors: app.state.show_colors }, rect, &mut app.state.standings);
 }
 
 fn draw_win_probability(f: &mut Frame, rect: Rect, app: &mut App) {

--- a/src/keys.rs
+++ b/src/keys.rs
@@ -350,6 +350,9 @@ async fn handle_global_key(
             load_standings(guard, network_requests).await;
         }
         (Char('?'), _) => guard.update_tab(MenuItem::Help),
+        (Char('c'), KeyModifiers::NONE) => {
+            guard.state.show_colors = !guard.state.show_colors;
+        }
         (Char('d'), _) => guard.toggle_debug(),
         (Char('"'), _) => {
             if guard.state.debug_state == DebugState::On {

--- a/src/state/app_state.rs
+++ b/src/state/app_state.rs
@@ -15,12 +15,12 @@ pub enum HomeOrAway {
     Away = 1,
 }
 
-#[derive(Default)]
 pub struct AppState {
     pub active_tab: MenuItem,
     pub previous_tab: MenuItem,
     pub debug_state: DebugState,
     pub show_logs: bool,
+    pub show_colors: bool,
     pub date_input: DateInput,
     pub schedule: ScheduleState,
     pub gameday: GamedayState,
@@ -28,4 +28,23 @@ pub struct AppState {
     pub standings: StandingsState,
     pub stats: StatsState,
     pub help: HelpState,
+}
+
+impl Default for AppState {
+    fn default() -> Self {
+        AppState {
+            show_colors: true,
+            active_tab: Default::default(),
+            previous_tab: Default::default(),
+            debug_state: Default::default(),
+            show_logs: Default::default(),
+            date_input: Default::default(),
+            schedule: Default::default(),
+            gameday: Default::default(),
+            box_score: Default::default(),
+            standings: Default::default(),
+            stats: Default::default(),
+            help: Default::default(),
+        }
+    }
 }

--- a/src/state/boxscore.rs
+++ b/src/state/boxscore.rs
@@ -165,15 +165,17 @@ impl BoxscoreState {
     pub fn get_batting_rows<'a>(
         &'a self,
         team: HomeOrAway,
+        show_colors: bool,
     ) -> impl Iterator<Item = Vec<Cell<'a>>> + 'a {
-        self.boxscore.to_batting_table_rows(team)
+        self.boxscore.to_batting_table_rows(team, show_colors)
     }
 
     pub fn get_pitching_rows<'a>(
         &'a self,
         team: HomeOrAway,
-    ) -> impl Iterator<Item = Vec<Cell<'a>>> + 'a {
-        self.boxscore.to_pitching_table_rows(team)
+        show_colors: bool,
+    ) -> Box<dyn Iterator<Item = Vec<Cell<'a>>> + 'a> {
+        self.boxscore.to_pitching_table_rows(team, show_colors)
     }
 
     pub fn get_batting_notes_paragraph(&self, team: HomeOrAway) -> Option<&Paragraph<'static>> {

--- a/src/ui/boxscore.rs
+++ b/src/ui/boxscore.rs
@@ -33,6 +33,7 @@ const PITCHING_HEADER: &[&str] = &["pitcher", "ip", "h", "r", "er", "bb", "k", "
 pub struct TeamBatterBoxscoreWidget<'a> {
     pub active: HomeOrAway,
     pub state: &'a mut BoxscoreState,
+    pub show_colors: bool,
 }
 
 impl Widget for TeamBatterBoxscoreWidget<'_> {
@@ -73,7 +74,7 @@ impl TeamBatterBoxscoreWidget<'_> {
         if let Some((visible_boxscore, _)) = adjust_area_for_scroll(boxscore_area, params) {
             Widget::render(
                 create_table(
-                    self.state.get_batting_rows(self.active),
+                    self.state.get_batting_rows(self.active, self.show_colors),
                     &BATTER_WIDTHS,
                     BATTING_HEADER,
                     scroll_offset as usize,
@@ -96,7 +97,7 @@ impl TeamBatterBoxscoreWidget<'_> {
                 .saturating_sub(notes_height + 1); // +1 for space
             Widget::render(
                 create_table(
-                    self.state.get_pitching_rows(self.active),
+                    self.state.get_pitching_rows(self.active, self.show_colors),
                     &PITCHER_WIDTHS,
                     PITCHING_HEADER,
                     offset as usize,
@@ -124,7 +125,7 @@ impl TeamBatterBoxscoreWidget<'_> {
 
         Widget::render(
             create_table(
-                self.state.get_batting_rows(self.active),
+                self.state.get_batting_rows(self.active, self.show_colors),
                 &BATTER_WIDTHS,
                 BATTING_HEADER,
                 0,
@@ -139,7 +140,7 @@ impl TeamBatterBoxscoreWidget<'_> {
 
         Widget::render(
             create_table(
-                self.state.get_pitching_rows(self.active),
+                self.state.get_pitching_rows(self.active, self.show_colors),
                 &PITCHER_WIDTHS,
                 PITCHING_HEADER,
                 0,

--- a/src/ui/gameday/gameday_widget.rs
+++ b/src/ui/gameday/gameday_widget.rs
@@ -16,6 +16,7 @@ pub struct GamedayWidget<'a> {
     pub state: &'a GamedayState,
     pub boxscore_state: &'a mut BoxscoreState,
     pub active: HomeOrAway,
+    pub show_colors: bool,
 }
 
 impl Widget for GamedayWidget<'_> {
@@ -33,12 +34,14 @@ impl Widget for GamedayWidget<'_> {
             let linescore_widget = LineScoreWidget {
                 active: self.active,
                 linescore: &self.state.game.linescore,
+                show_colors: self.show_colors,
             };
             Widget::render(linescore_widget, chunks[0], buf);
 
             let boxscore_widget = TeamBatterBoxscoreWidget {
                 active: self.active,
                 state: self.boxscore_state,
+                show_colors: self.show_colors,
             };
             Widget::render(boxscore_widget, chunks[1], buf);
         }

--- a/src/ui/help.rs
+++ b/src/ui/help.rs
@@ -6,7 +6,7 @@ use tui::prelude::*;
 use tui::widgets::{Paragraph, Row, Table, TableState};
 
 const HEADER: &[&str; 2] = &["Description", "Key"];
-const GENERAL_DOCS: &[&[&str; 2]; 7] = &[
+const GENERAL_DOCS: &[&[&str; 2]; 8] = &[
     &["Exit help", "Esc"],
     &["Move down", "j/↓"],
     &["Move up", "k/↑"],
@@ -14,6 +14,7 @@ const GENERAL_DOCS: &[&[&str; 2]; 7] = &[
     &["Page up", "Shift + k/↑"],
     &["Quit", "q"],
     &["Full screen", "f"],
+    &["Toggle colors", "c"],
 ];
 const SCOREBOARD_DOCS: &[&[&str; 2]; 9] = &[
     &["Scoreboard", "1"],

--- a/src/ui/linescore.rs
+++ b/src/ui/linescore.rs
@@ -13,6 +13,7 @@ use tui::{
 pub struct LineScoreWidget<'a> {
     pub active: HomeOrAway,
     pub linescore: &'a LineScore,
+    pub show_colors: bool,
 }
 
 impl Widget for LineScoreWidget<'_> {
@@ -34,8 +35,8 @@ impl Widget for LineScoreWidget<'_> {
 
         let t = Table::new(
             vec![
-                Row::new(self.linescore.away.create_score_vec(self.active)),
-                Row::new(self.linescore.home.create_score_vec(self.active)),
+                Row::new(self.linescore.away.create_score_vec(self.active, self.show_colors)),
+                Row::new(self.linescore.home.create_score_vec(self.active, self.show_colors)),
             ],
             widths.as_slice(),
         )

--- a/src/ui/player_profile.rs
+++ b/src/ui/player_profile.rs
@@ -9,6 +9,7 @@ use tui::widgets::{Block, BorderType, Borders, Padding, Paragraph, Row, Table};
 
 pub struct PlayerProfileWidget<'a> {
     pub state: &'a mut PlayerProfileState,
+    pub show_colors: bool,
 }
 
 impl Widget for PlayerProfileWidget<'_> {
@@ -136,7 +137,7 @@ impl PlayerProfileWidget<'_> {
     fn render_season(&self, area: Rect, skip: u16, buf: &mut Buffer) {
         let title = format!("{} Season", self.state.season_year);
         let splits = &self.state.profile.splits.season;
-        render_stat_table(&title, splits, None, false, area, skip, buf);
+        render_stat_table(&title, splits, None, false, self.show_colors, area, skip, buf);
     }
 
     fn render_career(&self, area: Rect, skip: u16, buf: &mut Buffer) {
@@ -152,6 +153,7 @@ impl PlayerProfileWidget<'_> {
                 &splits.year_by_year,
                 career_totals,
                 true,
+                self.show_colors,
                 area,
                 skip,
                 buf,
@@ -163,7 +165,7 @@ impl PlayerProfileWidget<'_> {
         let recent_splits = &self.state.profile.splits.recent_splits;
         let is_hitting = matches!(self.state.stat_group, StatGroup::Hitting);
         if let Some((header, widths, rows)) =
-            PlayerProfile::build_splits_rows(recent_splits, is_hitting)
+            PlayerProfile::build_splits_rows(recent_splits, is_hitting, self.show_colors)
         {
             render_table_with_title("Splits", header, widths, rows, area, skip, buf);
         }
@@ -171,7 +173,7 @@ impl PlayerProfileWidget<'_> {
 
     fn render_game_log(&self, area: Rect, skip: u16, buf: &mut Buffer) {
         let splits = &self.state.profile.splits.game_log;
-        if let Some((header, widths, rows)) = PlayerProfile::build_game_log_rows(splits) {
+        if let Some((header, widths, rows)) = PlayerProfile::build_game_log_rows(splits, self.show_colors) {
             render_table_with_title("Recent Games", header, widths, rows, area, skip, buf);
         }
     }
@@ -183,6 +185,7 @@ fn render_stat_table(
     splits: &[Split],
     career: Option<&Vec<Split>>,
     show_year: bool,
+    show_colors: bool,
     area: Rect,
     skip: u16,
     buf: &mut Buffer,
@@ -204,10 +207,10 @@ fn render_stat_table(
         return;
     }
 
-    if let Some((header, widths, mut rows)) = PlayerProfile::build_stat_rows(splits, show_year) {
+    if let Some((header, widths, mut rows)) = PlayerProfile::build_stat_rows(splits, show_year, show_colors) {
         if let Some(total) = career.and_then(|c| c.first()) {
             rows.push(
-                Row::new(PlayerProfile::career_total_cells(total)).style(Style::default().bold()),
+                Row::new(PlayerProfile::career_total_cells(total, show_colors)).style(Style::default().bold()),
             );
         }
         render_table_with_title(title, header, widths, rows, area, skip, buf);

--- a/src/ui/standings.rs
+++ b/src/ui/standings.rs
@@ -23,7 +23,9 @@ const WIDTHS: [Constraint; 14] = [
     Constraint::Length(8),
 ];
 
-pub struct StandingsWidget {}
+pub struct StandingsWidget {
+    pub show_colors: bool,
+}
 
 impl StatefulWidget for StandingsWidget {
     type State = StandingsState;
@@ -46,14 +48,14 @@ impl StatefulWidget for StandingsWidget {
                     rows.push(division);
                     // then add all the teams in the division
                     for s in &d.standings {
-                        rows.push(Row::new(s.to_cells()).height(1))
+                        rows.push(Row::new(s.to_cells(self.show_colors)).height(1))
                     }
                 }
             }
             ViewMode::Overall => {
                 // Show all teams sorted by record without division headers
                 for t in &state.league_standings {
-                    rows.push(Row::new(t.to_cells()).height(1));
+                    rows.push(Row::new(t.to_cells(self.show_colors)).height(1));
                 }
             }
         }

--- a/src/ui/stats.rs
+++ b/src/ui/stats.rs
@@ -9,7 +9,9 @@ use tui::widgets::{Block, BorderType, Borders, Cell, Padding, Paragraph, Row, Ta
 pub const STATS_OPTIONS_WIDTH: u16 = 36;
 
 /// Renders the stats data table (left pane).
-pub struct StatsDataWidget {}
+pub struct StatsDataWidget {
+    pub show_colors: bool,
+}
 
 impl StatefulWidget for StatsDataWidget {
     type State = StatsState;
@@ -49,9 +51,11 @@ impl StatefulWidget for StatsDataWidget {
                     .iter()
                     .zip(row.iter())
                     .map(|(col_name, cell)| {
-                        if col_name == "AVG" {
+                        if self.show_colors && col_name == "AVG" {
                             Cell::from(cell.as_str())
                                 .fg(avg_color(cell).unwrap_or(Color::White))
+                        } else if self.show_colors && cell == "0" {
+                            Cell::from(cell.as_str()).fg(Color::DarkGray)
                         } else {
                             Cell::from(cell.as_str())
                         }

--- a/src/ui/stats.rs
+++ b/src/ui/stats.rs
@@ -1,3 +1,4 @@
+use crate::components::boxscore::avg_color;
 use crate::components::stats::table::TeamOrPlayer;
 use crate::components::stats::{STATS_DEFAULT_COL_WIDTH, STATS_FIRST_COL_WIDTH};
 use crate::state::stats::{ActivePane, StatsState};
@@ -15,7 +16,7 @@ impl StatefulWidget for StatsDataWidget {
 
     fn render(self, area: Rect, buf: &mut Buffer, state: &mut Self::State) {
         let table = state.generate_table();
-        let (header, _, rows) = table.as_ref();
+        let (col_names, _, rows) = table.as_ref();
 
         // use the sort column to include up/down arrow in the column name
         let sort_column = state
@@ -24,7 +25,7 @@ impl StatefulWidget for StatsDataWidget {
             .column_name
             .as_deref()
             .unwrap_or_default();
-        let header = header
+        let header = col_names
             .iter()
             .map(|name| {
                 if name == sort_column {
@@ -44,8 +45,17 @@ impl StatefulWidget for StatsDataWidget {
         let rows: Vec<Row> = rows
             .iter()
             .map(|row| {
-                row.iter()
-                    .map(|cell| Cell::from(cell.as_str()))
+                col_names
+                    .iter()
+                    .zip(row.iter())
+                    .map(|(col_name, cell)| {
+                        if col_name == "AVG" {
+                            Cell::from(cell.as_str())
+                                .fg(avg_color(cell).unwrap_or(Color::White))
+                        } else {
+                            Cell::from(cell.as_str())
+                        }
+                    })
                     .collect::<Row>()
             })
             .collect();


### PR DESCRIPTION
## Summary

Adds contextual color highlights to stats across the TUI, all toggled globally with `c`
 (documented in the help menu)

- **Batting average** — `Color::Green` for ≥ .300, `Color::Red` for < .100,
`Color::DarkGray` for .000, unstyled otherwise; applied everywhere AVG appears (boxscore,
 player profile season stats / game log / recent splits, stats leaderboard)
- **Win percentage** — `Color::Green` for ≥ .500, `Color::Red` for < .500,
`Color::DarkGray` for .000; applied to the PCT column in standings
- **Zero dimming** — `Color::DarkGray` on any `0` value in: inning linescore (per-inning
scores + R/H/E totals), batter boxscore stat columns (AB/R/H/RBI/BB/K/LOB), pitcher
boxscore stat columns (H/R/ER/BB/K/HR), and the stats leaderboard
- `---` / non-numeric values are always left unstyled

| Stat | Green | Red | Dark gray |
|------|-------|-----|------|
| Batting average | ≥ .300 | < .100 | .000 |
| Win percentage | ≥ .500 | < .500 | .000 |
| Numeric zeros (linescore, boxscore, leaderboard) |  |  | `0` |

## Changes

- `src/components/boxscore.rs` — added `avg_color` and `win_pct_color` helpers;
zero-dimming in batter and pitcher `to_cells`
- `src/components/linescore.rs` — zero-dimming in `create_score_vec`
- `src/components/standings.rs` — `win_pct_color` applied to PCT cell
- `src/components/stats/player_profile.rs` — `avg_color` applied to season stats, game
log, and recent splits AVG cells
- `src/ui/stats.rs` — `avg_color` on AVG column, zero-dimming on all `"0"` cells
- `src/state/app_state.rs` — added `show_colors: bool` (default `true`)
- `src/keys.rs` — `c` toggles `show_colors` globally
- `src/ui/help.rs` — added "Toggle colors" / `c` to General section

## Screenshots

<img width="1582" height="1035" alt="Screenshot 2026-04-03 at 4 51 22 PM" src="https://github.com/user-attachments/assets/cb1e5ac9-506e-4f4f-9786-397096b41b90" />

<img width="1582" height="1035" alt="Screenshot 2026-04-03 at 4 51 35 PM" src="https://github.com/user-attachments/assets/b9cf909c-6b35-4a1b-a50f-587867b90487" />

<img width="1582" height="1035" alt="Screenshot 2026-04-03 at 4 55 52 PM" src="https://github.com/user-attachments/assets/fae4ff13-5901-4437-83b9-2f65fb955d08" />

---

My first time contributing to a Rust project and I have to say... THIS TUI IS BANGER!! ⚾ I also maintain an MLB web app at [mlb.theohtani.com](https://github.com/nuotsu/mlb) where I implemented similar stat coloring; it's a small touch but goes a long way in visually surfacing hot/cold hitters and strong/weak teams at a glance. Thought it'd be a nice addition here too!