### PR TITLE
Fix: add short team name aliases to TEAM_IDS

### DIFF
--- a/src/components/constants.rs
+++ b/src/components/constants.rs
@@ -147,5 +147,9 @@ pub static TEAM_IDS: LazyLock<HashMap<&'static str, Team>> = LazyLock::new(|| {
     m.insert("New York Giants", Team { id: 137, division_id: 0, name: "New York Giants", team_name: "Giants", abbreviation: "NYG" });
     m.insert("Boston Braves", Team { id: 144, division_id: 0, name: "Boston Braves", team_name: "Braves", abbreviation: "BSN" });
     m.insert("St. Louis Browns", Team { id: 110, division_id: 0, name: "St. Louis Browns", team_name: "Browns", abbreviation: "SLB" });
+    // Short names — the standings and schedule API endpoints return these instead of full names
+    for team in CURRENT_TEAMS.values() {
+        m.entry(team.team_name).or_insert(*team);
+    }
     m
 });


### PR DESCRIPTION
## Summary

- The MLB Stats API standings/schedule endpoints now return short team names (e.g. "Blue Jays") instead of full names ("Toronto Blue Jays")
- Adds `team_name` values from `CURRENT_TEAMS` as additional keys in `TEAM_IDS` so the static lookup doesn't fall back to "unknown"
- The dynamic cache from `register_teams()` covers this at runtime, but standings data can arrive before the teams API call completes

Fixes #121

## Test plan

- [ ] Open Standings tab — all 30 team names should display correctly
- [ ] Open Scoreboard tab — team names resolve in schedule rows
- [ ] Verify no regressions in Stats or Gameday tabs

🤖 Generated with [Claude Code](https://claude.ai/claude-code)