### PR TITLE
Fix challenge team id in API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Fix Stats page option pane selection: [PR 119](https://github.com/mlb-rs/mlbt/pull/119)
+- Fix challenge API response: [PR 126](https://github.com/mlb-rs/mlbt/pull/126)
 
 ## [0.2.0] - 2026-03-30
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1427,7 +1427,7 @@ dependencies = [
 
 [[package]]
 name = "mlbt-api"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "chrono",
  "derive_builder",

--- a/api/Cargo.toml
+++ b/api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mlbt-api"
-version = "0.4.0"
+version = "0.4.1"
 authors = ["Andrew Schneider <andjschneider@gmail.com>"]
 edition = "2024"
 description = "Internal API client for mlbt"

--- a/api/src/plays.rs
+++ b/api/src/plays.rs
@@ -97,9 +97,9 @@ pub struct PlayEvent {
 #[derive(Default, Debug, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ReviewDetails {
-    pub is_overturned: bool,
-    pub in_progress: bool,
-    pub review_type: String,
+    pub is_overturned: Option<bool>,
+    pub in_progress: Option<bool>,
+    pub review_type: Option<String>,
     pub challenge_team_id: Option<u16>,
     pub player: Option<Person>,
 }

--- a/api/src/plays.rs
+++ b/api/src/plays.rs
@@ -100,7 +100,7 @@ pub struct ReviewDetails {
     pub is_overturned: bool,
     pub in_progress: bool,
     pub review_type: String,
-    pub challenge_team_id: u16,
+    pub challenge_team_id: Option<u16>,
     pub player: Option<Person>,
 }
 

--- a/src/components/game/review.rs
+++ b/src/components/game/review.rs
@@ -4,10 +4,10 @@ use tui::prelude::{Span, Style};
 
 #[derive(Debug)]
 pub struct ReviewDetails {
-    pub is_overturned: bool,
-    pub in_progress: bool,
+    pub is_overturned: Option<bool>,
+    pub in_progress: Option<bool>,
     // pub review_type: String, // TODO not sure what this is yet
-    /// Team that initiated the review.
+    /// Team that initiated the review. If None, usually means it was a crew chief review.
     pub challenge_team_id: Option<u16>,
     /// Player that initiated the review, if any.
     pub player_id: Option<PlayerId>,
@@ -51,16 +51,17 @@ impl ReviewDetails {
         })
     }
 
-    /// Returns the completed review status: " | Overturned [Ruth]" or " | Upheld [Ruth]"
+    /// Returns the completed review status: " | Overturned [Ruth]", " | Upheld [Ruth]", or
+    /// " | Challenged [Ruth]" when the outcome is unknown.
     pub fn format_status_spans(&self, player_map: &PlayerMap) -> Option<Vec<Span<'static>>> {
-        if self.in_progress {
+        if self.in_progress.unwrap_or(true) {
             return None;
         }
 
-        let status = if self.is_overturned {
-            "Overturned"
-        } else {
-            "Upheld"
+        let status = match self.is_overturned {
+            Some(true) => "Overturned",
+            Some(false) => "Upheld",
+            None => "Challenged",
         };
 
         let mut spans = vec![Span::raw(format!(" | {status}"))];
@@ -81,7 +82,7 @@ impl ReviewDetails {
         away_team: &Team,
         player_map: &PlayerMap,
     ) -> Option<Vec<Span<'static>>> {
-        if !self.in_progress {
+        if !self.in_progress.unwrap_or(false) {
             return None;
         }
 
@@ -144,8 +145,8 @@ mod tests {
         player_id: Option<u64>,
     ) -> ReviewDetails {
         ReviewDetails {
-            is_overturned: overturned,
-            in_progress,
+            is_overturned: Some(overturned),
+            in_progress: Some(in_progress),
             challenge_team_id: Some(team_id),
             player_id,
         }
@@ -188,6 +189,44 @@ mod tests {
                 .unwrap(),
         );
         assert!(text.contains("Overturned") && !text.contains("["));
+    }
+
+    #[test]
+    fn status_unknown_outcome_falls_back_to_challenged() {
+        let review = ReviewDetails {
+            is_overturned: None,
+            in_progress: Some(false),
+            challenge_team_id: Some(147),
+            player_id: Some(1),
+        };
+        let text = spans_text(&review.format_status_spans(&players()).unwrap());
+        assert!(text.contains("Challenged") && text.contains("[Ruth]"));
+    }
+
+    #[test]
+    fn status_returns_none_when_state_unknown() {
+        let review = ReviewDetails {
+            is_overturned: Some(true),
+            in_progress: None,
+            challenge_team_id: Some(147),
+            player_id: Some(1),
+        };
+        assert!(review.format_status_spans(&players()).is_none());
+    }
+
+    #[test]
+    fn in_progress_returns_none_when_state_unknown() {
+        let review = ReviewDetails {
+            is_overturned: Some(true),
+            in_progress: None,
+            challenge_team_id: Some(147),
+            player_id: Some(1),
+        };
+        assert!(
+            review
+                .format_in_progress_spans(&HOME, &AWAY, &players())
+                .is_none()
+        );
     }
 
     #[test]

--- a/src/components/game/review.rs
+++ b/src/components/game/review.rs
@@ -8,7 +8,7 @@ pub struct ReviewDetails {
     pub in_progress: bool,
     // pub review_type: String, // TODO not sure what this is yet
     /// Team that initiated the review.
-    pub challenge_team_id: u16,
+    pub challenge_team_id: Option<u16>,
     /// Player that initiated the review, if any.
     pub player_id: Option<PlayerId>,
 }
@@ -27,13 +27,15 @@ impl From<&mlbt_api::plays::ReviewDetails> for ReviewDetails {
 
 impl ReviewDetails {
     fn team_abbreviation<'a>(&self, home_team: &'a Team, away_team: &'a Team) -> Option<&'a str> {
-        if self.challenge_team_id == home_team.id {
-            Some(home_team.abbreviation)
-        } else if self.challenge_team_id == away_team.id {
-            Some(away_team.abbreviation)
-        } else {
-            None
-        }
+        self.challenge_team_id.and_then(|id| {
+            if id == home_team.id {
+                Some(home_team.abbreviation)
+            } else if id == away_team.id {
+                Some(away_team.abbreviation)
+            } else {
+                None
+            }
+        })
     }
 
     fn player_name(&self, player_map: &PlayerMap) -> Option<String> {
@@ -144,7 +146,7 @@ mod tests {
         ReviewDetails {
             is_overturned: overturned,
             in_progress,
-            challenge_team_id: team_id,
+            challenge_team_id: Some(team_id),
             player_id,
         }
     }


### PR DESCRIPTION
The Cubs game on 4/13 had a crew chief review, causing  the `challenge_team_id` to be missing from the API.

To be defensive, I just made every API field optional.