### PR TITLE
Add network caching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Add color highlighting to stats. Thanks @nuotsu! [PR 118](https://github.com/mlb-rs/mlbt/pull/118)
+- Add caching for API calls: [PR 127](https://github.com/mlb-rs/mlbt/pull/127)
 
 ### Fixed
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1427,7 +1427,7 @@ dependencies = [
 
 [[package]]
 name = "mlbt-api"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "chrono",
  "derive_builder",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,7 @@ crossterm = "0.29.0"
 directories = "6.0.0"
 indexmap = "2.13.0"
 log = "0.4.29"
-mlbt-api = { path = "api", version = "0.4.0" }
+mlbt-api = { path = "api", version = "0.4.1" }
 nucleo-matcher = "0.3.1"
 serde = { version = "1.0.228", features = ["derive"] }
 tokio = { version = "1.49.0", features = ["full"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,7 @@ crossterm = "0.29.0"
 directories = "6.0.0"
 indexmap = "2.13.0"
 log = "0.4.29"
-mlbt-api = { path = "api", version = "0.4.1" }
+mlbt-api = { path = "api", version = "0.4.2" }
 nucleo-matcher = "0.3.1"
 serde = { version = "1.0.228", features = ["derive"] }
 tokio = { version = "1.49.0", features = ["full"] }

--- a/api/Cargo.toml
+++ b/api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mlbt-api"
-version = "0.4.1"
+version = "0.4.2"
 authors = ["Andrew Schneider <andjschneider@gmail.com>"]
 edition = "2024"
 description = "Internal API client for mlbt"

--- a/api/src/client.rs
+++ b/api/src/client.rs
@@ -51,7 +51,7 @@ impl ApiError {
 /// The available stat groups. These are taken from the "meta" endpoint:
 /// https://statsapi.mlb.com/api/v1/statGroups
 /// I only need to use Hitting and Pitching for now.
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 pub enum StatGroup {
     Hitting,
     Pitching,

--- a/api/src/live.rs
+++ b/api/src/live.rs
@@ -1,8 +1,8 @@
 use crate::boxscore::Boxscore;
 use crate::plays::Plays;
-use std::collections::HashMap;
-
+use crate::schedule::Status;
 use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
 
 #[derive(Default, Debug, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -30,6 +30,7 @@ pub struct GameData {
     pub teams: Teams,
     pub players: HashMap<String, FullPlayer>,
     pub abs_challenges: Option<AbsChallenges>,
+    pub status: Status,
 }
 
 #[derive(Default, Debug, Serialize, Deserialize)]

--- a/api/src/schedule.rs
+++ b/api/src/schedule.rs
@@ -149,11 +149,12 @@ pub enum AbstractGameCode {
     F,
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Clone, Copy, Debug, PartialEq, Serialize, Deserialize)]
 pub enum AbstractGameState {
     Final,
     Live,
     Preview,
+    Other,
 }
 
 /// Only present if `hydrate=probablePitcher` is used.

--- a/api/src/season.rs
+++ b/api/src/season.rs
@@ -7,7 +7,7 @@ const SPRING_TRAINING_FALLBACK_MONTH: u32 = 3;
 const SPRING_TRAINING_FALLBACK_DAY: u32 = 20;
 
 /// Whether the date falls in spring training or the regular season.
-#[derive(Clone, Copy, Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 pub enum GameType {
     SpringTraining,
     RegularSeason,

--- a/api/src/team.rs
+++ b/api/src/team.rs
@@ -3,7 +3,7 @@ use crate::live::{FullPlayer, PrimaryPosition};
 use serde::Deserialize;
 use std::fmt;
 
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 pub enum RosterType {
     Active,
     FortyMan,

--- a/src/app.rs
+++ b/src/app.rs
@@ -7,6 +7,7 @@ use mlbt_api::schedule::ScheduleResponse;
 use mlbt_api::season::GameType;
 use mlbt_api::team::{RosterResponse, RosterType, TransactionsResponse};
 use mlbt_api::win_probability::WinProbabilityResponse;
+use std::sync::Arc;
 
 #[derive(Copy, Clone, Debug, Default, PartialEq)]
 pub enum MenuItem {
@@ -183,7 +184,7 @@ impl App {
         self.settings.full_screen = !self.settings.full_screen;
     }
 
-    pub fn update_player_profile(&mut self, data: PeopleResponse, game_type: GameType) {
+    pub fn update_player_profile(&mut self, data: Arc<PeopleResponse>, game_type: GameType) {
         match self.state.active_tab {
             MenuItem::Standings if self.state.standings.has_team_page() => {
                 self.state
@@ -204,9 +205,9 @@ impl App {
         &mut self,
         team_id: u16,
         date: NaiveDate,
-        schedule: ScheduleResponse,
-        roster: RosterResponse,
-        transactions: TransactionsResponse,
+        schedule: &ScheduleResponse,
+        roster: &RosterResponse,
+        transactions: &TransactionsResponse,
     ) {
         let tz = self.settings.timezone;
         match self.state.active_tab {
@@ -245,7 +246,7 @@ impl App {
     pub fn update_team_roster(
         &mut self,
         team_id: u16,
-        roster: RosterResponse,
+        roster: &RosterResponse,
         roster_type: RosterType,
     ) {
         match self.state.active_tab {

--- a/src/components/game/live_game.rs
+++ b/src/components/game/live_game.rs
@@ -7,6 +7,7 @@ use crate::components::standings::Team;
 use indexmap::IndexMap;
 use mlbt_api::live::LiveResponse;
 use mlbt_api::plays::Play;
+use mlbt_api::schedule::AbstractGameState;
 use mlbt_api::win_probability::WinProbabilityResponse;
 use std::collections::HashMap;
 use std::sync::LazyLock;
@@ -33,6 +34,7 @@ pub struct GameState {
     pub home_abs_challenges: Option<u8>,
     /// Remaining ABS challenges, if available.
     pub away_abs_challenges: Option<u8>,
+    pub abstract_game_state: Option<AbstractGameState>,
 }
 
 impl GameState {
@@ -46,6 +48,7 @@ impl GameState {
         self.set_teams(live_data);
         self.set_on_deck(live_data);
         self.set_abs_challenges(live_data);
+        self.abstract_game_state = live_data.game_data.status.abstract_game_state;
         self.current_at_bat = Self::get_current_play_ab_index(live_data);
         self.linescore = LineScore::from_live_data(live_data, &self.home_team, &self.away_team);
         if let Some(plays) = &live_data.live_data.plays.all_plays {

--- a/src/components/standings.rs
+++ b/src/components/standings.rs
@@ -11,6 +11,7 @@ use mlbt_api::standings::{RecordElement, StandingsResponse, TeamRecord};
 use mlbt_api::team::{RosterResponse, RosterType, TransactionsResponse};
 use std::collections::HashSet;
 use std::string::ToString;
+use std::sync::Arc;
 use tui::prelude::{Color, Stylize};
 use tui::widgets::{Cell, TableState};
 
@@ -266,9 +267,9 @@ impl StandingsState {
         &mut self,
         team_id: u16,
         date: NaiveDate,
-        schedule: ScheduleResponse,
-        roster: RosterResponse,
-        transactions: TransactionsResponse,
+        schedule: &ScheduleResponse,
+        roster: &RosterResponse,
+        transactions: &TransactionsResponse,
         tz: Tz,
     ) {
         let team = lookup_team_by_id(team_id).unwrap_or_default();
@@ -285,7 +286,7 @@ impl StandingsState {
     pub fn update_team_roster(
         &mut self,
         team_id: u16,
-        roster: RosterResponse,
+        roster: &RosterResponse,
         roster_type: RosterType,
     ) {
         if let Some(tp) = &mut self.team_page
@@ -295,7 +296,7 @@ impl StandingsState {
         }
     }
 
-    pub fn update_team_player_profile(&mut self, data: PeopleResponse, game_type: GameType) {
+    pub fn update_team_player_profile(&mut self, data: Arc<PeopleResponse>, game_type: GameType) {
         if let Some(tp) = &mut self.team_page {
             tp.update_player_profile(data, game_type);
         }

--- a/src/components/stats/table.rs
+++ b/src/components/stats/table.rs
@@ -18,7 +18,7 @@ pub const TEAM_COLUMN_NAME: &str = "Team";
 pub type TableData = (Vec<String>, Vec<u64>, Vec<Vec<String>>);
 
 /// Stores whether a team/player and pitching/hitting stat should be viewed.
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 pub struct StatType {
     pub group: StatGroup,
     pub team_player: TeamOrPlayer,
@@ -36,7 +36,7 @@ impl StatType {
     }
 }
 
-#[derive(Clone, Copy, Debug, Default, PartialEq)]
+#[derive(Clone, Copy, Debug, Default, Eq, Hash, PartialEq)]
 pub enum TeamOrPlayer {
     #[default]
     Team,

--- a/src/components/team_page.rs
+++ b/src/components/team_page.rs
@@ -38,14 +38,14 @@ pub struct TransactionRow {
 
 impl TeamGame {
     pub fn from_schedule(
-        response: ScheduleResponse,
+        response: &ScheduleResponse,
         team_id: u16,
         date: NaiveDate,
         tz: Tz,
     ) -> Vec<TeamGame> {
         let mut games = Vec::new();
-        for date_entry in response.dates {
-            let Some(date_games) = date_entry.games else {
+        for date_entry in &response.dates {
+            let Some(date_games) = &date_entry.games else {
                 continue;
             };
             for game in date_games {
@@ -154,10 +154,10 @@ impl PositionGroup {
 }
 
 impl RosterRow {
-    pub fn from_roster(response: RosterResponse) -> Vec<RosterRow> {
+    pub fn from_roster(response: &RosterResponse) -> Vec<RosterRow> {
         let mut rows: Vec<RosterRow> = response
             .roster
-            .into_iter()
+            .iter()
             .map(|entry| {
                 let person = &entry.person;
                 let bats = person.bat_side.as_ref().map_display_or(|s| &s.code, "-");
@@ -196,12 +196,12 @@ impl RosterRow {
 }
 
 impl TransactionRow {
-    pub fn from_transactions(response: TransactionsResponse) -> Vec<TransactionRow> {
+    pub fn from_transactions(response: &TransactionsResponse) -> Vec<TransactionRow> {
         let mut rows: Vec<TransactionRow> = response
             .transactions
-            .into_iter()
+            .iter()
             .filter_map(|t| {
-                let description = t.description?;
+                let description = t.description.clone()?;
                 let date = t.date.as_ref().map_display_or(|d| format_short_date(d), "");
                 Some(TransactionRow { date, description })
             })

--- a/src/keys.rs
+++ b/src/keys.rs
@@ -1,7 +1,8 @@
 use crate::app::{App, DebugState, MenuItem};
+use crate::cleanup_terminal;
 use crate::components::stats::table::TeamOrPlayer;
+use crate::state::messages::{NetworkRequest, RefreshableRequest};
 use crate::state::stats::ActivePane;
-use crate::{NetworkRequest, cleanup_terminal};
 use crossterm::event::KeyCode::Char;
 use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 use mlbt_api::client::StatGroup;
@@ -13,7 +14,7 @@ type AppGuard<'a> = MutexGuard<'a, App>;
 pub async fn handle_key_bindings(
     key_event: KeyEvent,
     app: &Arc<Mutex<App>>,
-    network_requests: &mpsc::Sender<NetworkRequest>,
+    network_requests: &mpsc::Sender<RefreshableRequest>,
 ) {
     let mut guard = app.lock().await;
     match (guard.state.active_tab, key_event.code, key_event.modifiers) {
@@ -100,20 +101,20 @@ pub async fn handle_key_bindings(
         }
         (MenuItem::Scoreboard, Char('j') | KeyCode::Down, _) => {
             guard.state.schedule.next();
-            load_game_data(guard, network_requests).await;
+            load_game_data(guard, network_requests, false).await;
         }
         (MenuItem::Scoreboard, Char('K') | KeyCode::Up, KeyModifiers::SHIFT) => {
             guard.state.box_score.scroll_up()
         }
         (MenuItem::Scoreboard, Char('k') | KeyCode::Up, _) => {
             guard.state.schedule.previous();
-            load_game_data(guard, network_requests).await;
+            load_game_data(guard, network_requests, false).await;
         }
         (MenuItem::Scoreboard, Char(':'), _) => guard.update_tab(MenuItem::DatePicker),
         (MenuItem::Scoreboard, Char('w'), _) => guard.state.schedule.toggle_win_probability(),
         (MenuItem::Scoreboard, KeyCode::Enter, _) => {
             guard.update_tab(MenuItem::Gameday);
-            load_game_data(guard, network_requests).await;
+            load_game_data(guard, network_requests, false).await;
         }
 
         (MenuItem::DatePicker, KeyCode::Enter, _) => {
@@ -151,19 +152,19 @@ pub async fn handle_key_bindings(
         (MenuItem::Stats, Char('o'), _) => guard.state.stats.toggle_options(),
         (MenuItem::Stats, Char('p'), _) => {
             guard.state.stats.stat_type.group = StatGroup::Pitching;
-            load_stats(guard, network_requests).await;
+            load_stats(guard, network_requests, false).await;
         }
         (MenuItem::Stats, Char('h'), _) => {
             guard.state.stats.stat_type.group = StatGroup::Hitting;
-            load_stats(guard, network_requests).await;
+            load_stats(guard, network_requests, false).await;
         }
         (MenuItem::Stats, Char('l'), _) => {
             guard.state.stats.stat_type.team_player = TeamOrPlayer::Player;
-            load_stats(guard, network_requests).await;
+            load_stats(guard, network_requests, false).await;
         }
         (MenuItem::Stats, Char('t'), _) => {
             guard.state.stats.stat_type.team_player = TeamOrPlayer::Team;
-            load_stats(guard, network_requests).await;
+            load_stats(guard, network_requests, false).await;
         }
         (MenuItem::Stats, KeyCode::Enter, _) => {
             if guard.state.stats.active_pane == ActivePane::Options {
@@ -219,77 +220,107 @@ pub async fn handle_key_bindings(
     }
 }
 
-async fn load_team(guard: AppGuard<'_>, network_requests: &mpsc::Sender<NetworkRequest>) {
+async fn load_team(guard: AppGuard<'_>, network_requests: &mpsc::Sender<RefreshableRequest>) {
     let team_id = guard.state.standings.get_selected();
     let date = guard.state.standings.date_selector.date;
     drop(guard);
 
     let _ = network_requests
-        .send(NetworkRequest::TeamPage { team_id, date })
+        .send(NetworkRequest::TeamPage { team_id, date }.into())
         .await;
 }
 
-async fn load_game_data(guard: AppGuard<'_>, network_requests: &mpsc::Sender<NetworkRequest>) {
+fn send_request(request: NetworkRequest, force: bool) -> RefreshableRequest {
+    if force {
+        RefreshableRequest::force(request)
+    } else {
+        request.into()
+    }
+}
+
+async fn load_game_data(
+    guard: AppGuard<'_>,
+    network_requests: &mpsc::Sender<RefreshableRequest>,
+    force: bool,
+) {
     let game_id = guard.state.schedule.get_selected_game_opt();
     drop(guard);
 
     if let Some(game_id) = game_id {
         let _ = network_requests
-            .send(NetworkRequest::GameData { game_id })
+            .send(send_request(NetworkRequest::GameData { game_id }, force))
             .await;
     }
 }
 
-async fn load_stats(guard: AppGuard<'_>, network_requests: &mpsc::Sender<NetworkRequest>) {
+async fn load_stats(
+    guard: AppGuard<'_>,
+    network_requests: &mpsc::Sender<RefreshableRequest>,
+    force: bool,
+) {
     let date = guard.state.stats.date_selector.date;
     let stat_type = guard.state.stats.stat_type;
     drop(guard);
 
     let _ = network_requests
-        .send(NetworkRequest::Stats { date, stat_type })
+        .send(send_request(
+            NetworkRequest::Stats { date, stat_type },
+            force,
+        ))
         .await;
 }
 
 async fn open_stats_selection(
     guard: AppGuard<'_>,
-    network_requests: &mpsc::Sender<NetworkRequest>,
+    network_requests: &mpsc::Sender<RefreshableRequest>,
 ) {
     if let Some(request) = guard.state.stats.open_selected_request() {
         drop(guard);
-        let _ = network_requests.send(request).await;
+        let _ = network_requests.send(request.into()).await;
     }
 }
 
-async fn load_standings(guard: AppGuard<'_>, network_requests: &mpsc::Sender<NetworkRequest>) {
+async fn load_standings(
+    guard: AppGuard<'_>,
+    network_requests: &mpsc::Sender<RefreshableRequest>,
+    force: bool,
+) {
     let date = guard.state.standings.date_selector.date;
     drop(guard);
 
     let _ = network_requests
-        .send(NetworkRequest::Standings { date })
+        .send(send_request(NetworkRequest::Standings { date }, force))
         .await;
 }
 
-async fn load_scoreboard(guard: AppGuard<'_>, network_requests: &mpsc::Sender<NetworkRequest>) {
+async fn load_scoreboard(
+    guard: AppGuard<'_>,
+    network_requests: &mpsc::Sender<RefreshableRequest>,
+    force: bool,
+) {
     let date = guard.state.schedule.date_selector.date;
     let game_id = guard.state.schedule.get_selected_game_opt();
     drop(guard);
 
     let _ = network_requests
-        .send(NetworkRequest::Schedule { date })
+        .send(send_request(NetworkRequest::Schedule { date }, force))
         .await;
 
     if let Some(game_id) = game_id {
         let _ = network_requests
-            .send(NetworkRequest::GameData { game_id })
+            .send(send_request(NetworkRequest::GameData { game_id }, force))
             .await;
     }
 }
 
-async fn handle_date_change(guard: AppGuard<'_>, network_requests: &mpsc::Sender<NetworkRequest>) {
+async fn handle_date_change(
+    guard: AppGuard<'_>,
+    network_requests: &mpsc::Sender<RefreshableRequest>,
+) {
     match guard.state.active_tab {
-        MenuItem::Scoreboard => load_scoreboard(guard, network_requests).await,
-        MenuItem::Standings => load_standings(guard, network_requests).await,
-        MenuItem::Stats => load_stats(guard, network_requests).await,
+        MenuItem::Scoreboard => load_scoreboard(guard, network_requests, false).await,
+        MenuItem::Standings => load_standings(guard, network_requests, false).await,
+        MenuItem::Stats => load_stats(guard, network_requests, false).await,
         _ => {}
     }
 }
@@ -300,7 +331,7 @@ async fn handle_profile_key(
     key_event: KeyEvent,
     profile: &mut Option<crate::state::player_profile::PlayerProfileState>,
     date: chrono::NaiveDate,
-    network_requests: &mpsc::Sender<NetworkRequest>,
+    network_requests: &mpsc::Sender<RefreshableRequest>,
 ) -> bool {
     let Some(p) = profile.as_mut() else {
         return false;
@@ -308,7 +339,7 @@ async fn handle_profile_key(
     match (key_event.code, key_event.modifiers) {
         (Char('s'), _) => {
             let req = p.game_type_toggle_request(date);
-            let _ = network_requests.send(req).await;
+            let _ = network_requests.send(req.into()).await;
         }
         (Char('J'), _) | (KeyCode::Down, KeyModifiers::SHIFT) => p.page_down(),
         (Char('K'), _) | (KeyCode::Up, KeyModifiers::SHIFT) => p.page_up(),
@@ -322,7 +353,7 @@ async fn handle_profile_key(
 async fn handle_global_key(
     key_event: KeyEvent,
     mut guard: AppGuard<'_>,
-    network_requests: &mpsc::Sender<NetworkRequest>,
+    network_requests: &mpsc::Sender<RefreshableRequest>,
 ) {
     match (key_event.code, key_event.modifiers) {
         (Char('q'), _) => {
@@ -331,23 +362,27 @@ async fn handle_global_key(
         }
         (Char('f'), m) if !m.contains(KeyModifiers::CONTROL) => guard.toggle_full_screen(),
         (Char('1'), _) => {
+            let force = guard.state.active_tab == MenuItem::Scoreboard;
             guard.update_tab(MenuItem::Scoreboard);
             guard.state.gameday.live(); // reset at bat selection
-            load_scoreboard(guard, network_requests).await;
+            load_scoreboard(guard, network_requests, force).await;
         }
         (Char('2'), _) => {
+            let force = guard.state.active_tab == MenuItem::Gameday;
             guard.update_tab(MenuItem::Gameday);
-            load_game_data(guard, network_requests).await;
+            load_game_data(guard, network_requests, force).await;
         }
         (Char('3'), _) => {
+            let force = guard.state.active_tab == MenuItem::Stats;
             guard.update_tab(MenuItem::Stats);
             if !guard.state.stats.has_player_profile() {
-                load_stats(guard, network_requests).await;
+                load_stats(guard, network_requests, force).await;
             }
         }
         (Char('4'), _) => {
+            let force = guard.state.active_tab == MenuItem::Standings;
             guard.update_tab(MenuItem::Standings);
-            load_standings(guard, network_requests).await;
+            load_standings(guard, network_requests, force).await;
         }
         (Char('?'), _) => guard.update_tab(MenuItem::Help),
         (Char('d'), _) => guard.toggle_debug(),
@@ -363,7 +398,7 @@ async fn handle_global_key(
 async fn handle_team_page_key(
     key_event: KeyEvent,
     team_page: &mut Option<crate::state::team_page::TeamPageState>,
-    network_requests: &mpsc::Sender<NetworkRequest>,
+    network_requests: &mpsc::Sender<RefreshableRequest>,
 ) -> bool {
     let Some(tp) = team_page.as_mut() else {
         return false;
@@ -384,11 +419,11 @@ async fn handle_team_page_key(
         (Char('c'), _) => tp.toggle_calendar(),
         (Char('r'), _) => {
             let req = tp.roster_toggle_request();
-            let _ = network_requests.send(req).await;
+            let _ = network_requests.send(req.into()).await;
         }
         (KeyCode::Enter, _) => {
             if let Some(req) = tp.player_profile_request() {
-                let _ = network_requests.send(req).await;
+                let _ = network_requests.send(req.into()).await;
             }
         }
         _ => return false,

--- a/src/keys.rs
+++ b/src/keys.rs
@@ -230,14 +230,6 @@ async fn load_team(guard: AppGuard<'_>, network_requests: &mpsc::Sender<Refresha
         .await;
 }
 
-fn send_request(request: NetworkRequest, force: bool) -> RefreshableRequest {
-    if force {
-        RefreshableRequest::force(request)
-    } else {
-        request.into()
-    }
-}
-
 async fn load_game_data(
     guard: AppGuard<'_>,
     network_requests: &mpsc::Sender<RefreshableRequest>,
@@ -248,7 +240,10 @@ async fn load_game_data(
 
     if let Some(game_id) = game_id {
         let _ = network_requests
-            .send(send_request(NetworkRequest::GameData { game_id }, force))
+            .send(RefreshableRequest::new(
+                NetworkRequest::GameData { game_id },
+                force,
+            ))
             .await;
     }
 }
@@ -263,7 +258,7 @@ async fn load_stats(
     drop(guard);
 
     let _ = network_requests
-        .send(send_request(
+        .send(RefreshableRequest::new(
             NetworkRequest::Stats { date, stat_type },
             force,
         ))
@@ -289,7 +284,10 @@ async fn load_standings(
     drop(guard);
 
     let _ = network_requests
-        .send(send_request(NetworkRequest::Standings { date }, force))
+        .send(RefreshableRequest::new(
+            NetworkRequest::Standings { date },
+            force,
+        ))
         .await;
 }
 
@@ -303,12 +301,18 @@ async fn load_scoreboard(
     drop(guard);
 
     let _ = network_requests
-        .send(send_request(NetworkRequest::Schedule { date }, force))
+        .send(RefreshableRequest::new(
+            NetworkRequest::Schedule { date },
+            force,
+        ))
         .await;
 
     if let Some(game_id) = game_id {
         let _ = network_requests
-            .send(send_request(NetworkRequest::GameData { game_id }, force))
+            .send(RefreshableRequest::new(
+                NetworkRequest::GameData { game_id },
+                force,
+            ))
             .await;
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -167,7 +167,7 @@ async fn handle_network_response(
             transactions,
         } => {
             let mut guard = app.lock().await;
-            guard.update_team_page(team_id, date, schedule, roster, transactions);
+            guard.update_team_page(team_id, date, &schedule, &roster, &transactions);
         }
         NetworkResponse::TeamRosterLoaded {
             team_id,
@@ -175,7 +175,7 @@ async fn handle_network_response(
             roster_type,
         } => {
             let mut guard = app.lock().await;
-            guard.update_team_roster(team_id, roster, roster_type);
+            guard.update_team_roster(team_id, &roster, roster_type);
         }
         NetworkResponse::Initialized => {
             // Teams must be loaded before the schedule so international team names resolve.

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,7 +7,7 @@ mod state;
 mod ui;
 
 use crate::app::App;
-use crate::state::messages::{NetworkRequest, NetworkResponse, UiEvent};
+use crate::state::messages::{NetworkRequest, NetworkResponse, RefreshableRequest, UiEvent};
 use crate::state::network::{LoadingState, NetworkWorker};
 use crate::state::refresher::PeriodicRefresher;
 use crossterm::event::{self as crossterm_event, Event};
@@ -41,7 +41,7 @@ async fn main() -> anyhow::Result<()> {
     let app = Arc::new(Mutex::new(App::new()));
 
     let (ui_event_tx, ui_event_rx) = mpsc::channel::<UiEvent>(100);
-    let (network_req_tx, network_req_rx) = mpsc::channel::<NetworkRequest>(100);
+    let (network_req_tx, network_req_rx) = mpsc::channel::<RefreshableRequest>(100);
     let (network_resp_tx, network_resp_rx) = mpsc::channel::<NetworkResponse>(100);
 
     // input handler thread
@@ -72,7 +72,7 @@ async fn main_ui_loop(
     mut terminal: Terminal<CrosstermBackend<Stdout>>,
     app: Arc<Mutex<App>>,
     mut ui_events: mpsc::Receiver<UiEvent>,
-    network_requests: mpsc::Sender<NetworkRequest>,
+    network_requests: mpsc::Sender<RefreshableRequest>,
     mut network_responses: mpsc::Receiver<NetworkResponse>,
 ) {
     let mut loading = LoadingState::default();
@@ -101,11 +101,13 @@ async fn main_ui_loop(
 async fn handle_ui_event(
     ui_event: UiEvent,
     app: &Arc<Mutex<App>>,
-    network_requests: &mpsc::Sender<NetworkRequest>,
+    network_requests: &mpsc::Sender<RefreshableRequest>,
 ) -> bool {
     match ui_event {
         UiEvent::AppStarted => {
-            let _ = network_requests.send(NetworkRequest::Initialize).await;
+            let _ = network_requests
+                .send(NetworkRequest::Initialize.into())
+                .await;
             true // Redraw immediately to show loading state
         }
         UiEvent::KeyPressed(key_event) => {
@@ -119,7 +121,7 @@ async fn handle_ui_event(
 async fn handle_network_response(
     response: NetworkResponse,
     app: &Arc<Mutex<App>>,
-    network_requests: &mpsc::Sender<NetworkRequest>,
+    network_requests: &mpsc::Sender<RefreshableRequest>,
     loading: &mut LoadingState,
 ) -> bool {
     match response {
@@ -136,7 +138,7 @@ async fn handle_network_response(
 
             if let Some(game_id) = game_id_to_load {
                 let _ = network_requests
-                    .send(NetworkRequest::GameData { game_id })
+                    .send(NetworkRequest::GameData { game_id }.into())
                     .await;
             }
         }
@@ -184,7 +186,7 @@ async fn handle_network_response(
                 guard.state.schedule.date_selector.date
             };
             let _ = network_requests
-                .send(NetworkRequest::Schedule { date })
+                .send(NetworkRequest::Schedule { date }.into())
                 .await;
         }
         NetworkResponse::Error { message } => {

--- a/src/state/cache.rs
+++ b/src/state/cache.rs
@@ -56,6 +56,10 @@ pub struct NetworkCache {
     /// Tracks the last known abstract game state per game_id, used to detect transitions to Final.
     /// The `Instant` records when the state was last observed from a schedule response.
     game_states: HashMap<u64, (AbstractGameState, Instant)>,
+    /// Schedule dates this process has observed with at least one non `Final` game.
+    /// Used to distinguish live observations (invalidate on Final) from historical browsing
+    /// (no invalidation, since current caches already reflect the result).
+    mutable_dates: HashMap<NaiveDate, Instant>,
     last_prune: Instant,
 }
 
@@ -64,6 +68,7 @@ impl NetworkCache {
         Self {
             entries: HashMap::new(),
             game_states: HashMap::new(),
+            mutable_dates: HashMap::new(),
             last_prune: Instant::now(),
         }
     }
@@ -129,6 +134,13 @@ impl NetworkCache {
         }
     }
 
+    fn has_fresh_mutable_date(&self, date: NaiveDate) -> bool {
+        matches!(
+            self.mutable_dates.get(&date),
+            Some(observed_at) if observed_at.elapsed() < PRUNE_AGE
+        )
+    }
+
     /// Insert a response with the default TTL for its key type. If the response is a schedule,
     /// automatically updates game state tracking and invalidates affected caches.
     pub fn insert(&mut self, key: CacheKey, response: NetworkResponse) {
@@ -170,15 +182,25 @@ impl NetworkCache {
             .retain(|_, entry| entry.fetched_at.elapsed() < PRUNE_AGE);
         self.game_states
             .retain(|_, (_, observed_at)| observed_at.elapsed() < PRUNE_AGE);
+        self.mutable_dates
+            .retain(|_, observed_at| observed_at.elapsed() < PRUNE_AGE);
         let removed = before - self.entries.len();
         debug!("pruned {removed} stale cache entries");
     }
 
-    /// Update tracked game states from a schedule response. When any game transitions to Final:
-    /// - Extends that game's cached data TTL to 1 hour (data is now static)
-    /// - Invalidates standings and stats caches for the request date only
-    fn update_game_states(&mut self, date: NaiveDate, schedule: &ScheduleResponse) {
-        let mut any_went_final = false;
+    /// Update tracked game states from a schedule response. When a game we previously observed
+    /// transitions to Final:
+    /// - Extends that game's cached data TTL (data is now static)
+    /// - Invalidates standings/stats caches for dates >= schedule_date (cumulative data stale)
+    /// - Invalidates team page caches for the teams involved (season wide schedules stale)
+    ///
+    /// If we've never observed the game or the schedule_date in a non-final state (e.g. user
+    /// browses an old date for the first time and all games there are already Final), we record
+    /// the state but don't invalidate, there's no evidence our current caches are stale.
+    fn update_game_states(&mut self, schedule_date: NaiveDate, schedule: &ScheduleResponse) {
+        let mut invalidate = false;
+        let mut affected_team_ids: Vec<u16> = Vec::new();
+        let mut saw_non_final = false;
 
         for date_entry in &schedule.dates {
             let Some(games) = &date_entry.games else {
@@ -189,11 +211,13 @@ impl NetworkCache {
                     continue;
                 };
                 let game_id = game.game_pk;
-                let was_final = matches!(
-                    self.game_states.get(&game_id),
-                    Some((AbstractGameState::Final, _))
-                );
+                let prior_state = self.game_states.get(&game_id).map(|(s, _)| *s);
+                let was_final = matches!(prior_state, Some(AbstractGameState::Final));
                 let is_final = matches!(new_state, AbstractGameState::Final);
+
+                if !is_final {
+                    saw_non_final = true;
+                }
 
                 if is_final && !was_final {
                     debug!("game {game_id} went Final, extending cache TTL");
@@ -201,7 +225,17 @@ impl NetworkCache {
                         entry.ttl = FINAL_GAME_TTL;
                         entry.fetched_at = Instant::now();
                     }
-                    any_went_final = true;
+                    // Only trust this transition as "live" if we previously saw the game
+                    // non-final OR we've observed this date as mutable in this process.
+                    let prior_non_final = matches!(
+                        prior_state,
+                        Some(AbstractGameState::Live | AbstractGameState::Preview)
+                    );
+                    if prior_non_final || self.has_fresh_mutable_date(schedule_date) {
+                        invalidate = true;
+                        affected_team_ids.push(game.teams.home.team.id);
+                        affected_team_ids.push(game.teams.away.team.id);
+                    }
                 }
 
                 self.game_states
@@ -209,10 +243,19 @@ impl NetworkCache {
             }
         }
 
-        if any_went_final {
-            debug!("invalidating standings and stats for {date} after game(s) went Final");
+        if saw_non_final {
+            self.mutable_dates.insert(schedule_date, Instant::now());
+        }
+
+        if invalidate {
+            debug!(
+                "invalidating standings/stats (>= {schedule_date}) and team pages for {affected_team_ids:?}"
+            );
             self.entries.retain(|key, _| match key {
-                CacheKey::Standings { date: d } | CacheKey::Stats { date: d, .. } => *d != date,
+                CacheKey::Standings { date: d } | CacheKey::Stats { date: d, .. } => {
+                    *d < schedule_date
+                }
+                CacheKey::TeamPage { team_id, .. } => !affected_team_ids.contains(team_id),
                 _ => true,
             });
         }
@@ -420,7 +463,7 @@ mod tests {
     }
 
     #[test]
-    fn unknown_to_final_counts_as_transition() {
+    fn unknown_to_final_does_not_invalidate_without_mutable_observation() {
         let mut cache = NetworkCache::new();
         let date = NaiveDate::from_ymd_opt(2026, 4, 13).unwrap();
 
@@ -431,11 +474,12 @@ mod tests {
             },
         );
 
-        // Game appears for the first time as Final (no prior state tracked)
+        // Game appears for the first time as Final. No prior state and no mutable date observed.
+        // This is likely historical browsing so current caches are not assumed stale.
         let schedule = make_schedule(TEST_DATE, vec![(456, AbstractGameState::Final)]);
         cache.update_game_states(test_date(), &schedule);
 
-        assert!(cache.get(&CacheKey::Standings { date }).is_none());
+        assert!(cache.get(&CacheKey::Standings { date }).is_some());
     }
 
     #[test]
@@ -480,12 +524,19 @@ mod tests {
         cache
             .game_states
             .insert(111, (AbstractGameState::Final, Instant::now() - PRUNE_AGE));
+        cache
+            .mutable_dates
+            .insert(test_date(), Instant::now() - PRUNE_AGE);
 
         // Insert a fresh entry
         cache.insert(CacheKey::GameData { game_id: 222 }, game_data_response());
         cache
             .game_states
             .insert(222, (AbstractGameState::Live, Instant::now()));
+        cache.mutable_dates.insert(
+            NaiveDate::from_ymd_opt(2026, 4, 14).unwrap(),
+            Instant::now(),
+        );
 
         cache.prune();
 
@@ -495,12 +546,18 @@ mod tests {
                 .contains_key(&CacheKey::GameData { game_id: 111 })
         );
         assert!(!cache.game_states.contains_key(&111));
+        assert!(!cache.mutable_dates.contains_key(&test_date()));
         assert!(
             cache
                 .entries
                 .contains_key(&CacheKey::GameData { game_id: 222 })
         );
         assert!(cache.game_states.contains_key(&222));
+        assert!(
+            cache
+                .mutable_dates
+                .contains_key(&NaiveDate::from_ymd_opt(2026, 4, 14).unwrap())
+        );
     }
 
     #[test]
@@ -527,24 +584,88 @@ mod tests {
     }
 
     #[test]
-    fn final_on_one_date_does_not_invalidate_other_dates() {
+    fn unobserved_historical_final_does_not_invalidate() {
         let mut cache = NetworkCache::new();
-        let apr13 = NaiveDate::from_ymd_opt(2026, 4, 13).unwrap();
-        let apr10 = NaiveDate::from_ymd_opt(2026, 4, 10).unwrap();
+        let past = NaiveDate::from_ymd_opt(2026, 4, 10).unwrap();
+        let today = NaiveDate::from_ymd_opt(2026, 4, 13).unwrap();
 
-        // Cache standings for both dates
         cache.insert(
-            CacheKey::Standings { date: apr13 },
+            CacheKey::Standings { date: today },
             NetworkResponse::StandingsLoaded {
                 standings: Arc::new(mlbt_api::standings::StandingsResponse::default()),
             },
         );
+
+        // User browses back to a past date so all games there are already Final.
+        // We've never observed game 123 nor the past date in a non final state.
+        let schedule = make_schedule("2026-04-10", vec![(123, AbstractGameState::Final)]);
+        cache.update_game_states(past, &schedule);
+
+        // No evidence the cached standings are stale.
+        assert!(cache.get(&CacheKey::Standings { date: today }).is_some());
+    }
+
+    #[test]
+    fn stale_mutable_date_does_not_authorize_invalidation() {
+        let mut cache = NetworkCache::new();
+        let past = NaiveDate::from_ymd_opt(2026, 4, 10).unwrap();
+        let today = NaiveDate::from_ymd_opt(2026, 4, 13).unwrap();
+
         cache.insert(
-            CacheKey::Standings { date: apr10 },
+            CacheKey::Standings { date: today },
             NetworkResponse::StandingsLoaded {
                 standings: Arc::new(mlbt_api::standings::StandingsResponse::default()),
             },
         );
+
+        cache
+            .mutable_dates
+            .insert(past, Instant::now() - PRUNE_AGE - Duration::from_secs(1));
+
+        let schedule = make_schedule("2026-04-10", vec![(123, AbstractGameState::Final)]);
+        cache.update_game_states(past, &schedule);
+
+        assert!(cache.get(&CacheKey::Standings { date: today }).is_some());
+    }
+
+    #[test]
+    fn observed_non_final_then_final_invalidates() {
+        let mut cache = NetworkCache::new();
+        let date = test_date();
+
+        cache.insert(
+            CacheKey::Standings { date },
+            NetworkResponse::StandingsLoaded {
+                standings: Arc::new(mlbt_api::standings::StandingsResponse::default()),
+            },
+        );
+
+        // Observe the game as Live first (establishes that we watched this date mutable)
+        let schedule = make_schedule(TEST_DATE, vec![(123, AbstractGameState::Live)]);
+        cache.update_game_states(date, &schedule);
+
+        // Then observe the transition to Final.  This is a real signal
+        let schedule = make_schedule(TEST_DATE, vec![(123, AbstractGameState::Final)]);
+        cache.update_game_states(date, &schedule);
+
+        assert!(cache.get(&CacheKey::Standings { date }).is_none());
+    }
+
+    #[test]
+    fn final_invalidates_from_transition_date_onward() {
+        let mut cache = NetworkCache::new();
+        let apr10 = NaiveDate::from_ymd_opt(2026, 4, 10).unwrap();
+        let apr13 = NaiveDate::from_ymd_opt(2026, 4, 13).unwrap();
+        let apr14 = NaiveDate::from_ymd_opt(2026, 4, 14).unwrap();
+
+        for date in [apr10, apr13, apr14] {
+            cache.insert(
+                CacheKey::Standings { date },
+                NetworkResponse::StandingsLoaded {
+                    standings: Arc::new(mlbt_api::standings::StandingsResponse::default()),
+                },
+            );
+        }
 
         // Game on Apr 13 goes Final
         let schedule = make_schedule(TEST_DATE, vec![(123, AbstractGameState::Live)]);
@@ -552,8 +673,93 @@ mod tests {
         let schedule = make_schedule(TEST_DATE, vec![(123, AbstractGameState::Final)]);
         cache.update_game_states(test_date(), &schedule);
 
-        // Apr 13 standings invalidated, Apr 10 standings preserved
-        assert!(cache.get(&CacheKey::Standings { date: apr13 }).is_none());
+        // Earlier date preserved, transition date and later invalidated
         assert!(cache.get(&CacheKey::Standings { date: apr10 }).is_some());
+        assert!(cache.get(&CacheKey::Standings { date: apr13 }).is_none());
+        assert!(cache.get(&CacheKey::Standings { date: apr14 }).is_none());
+    }
+
+    #[test]
+    fn final_invalidates_team_page_for_involved_teams() {
+        use mlbt_api::schedule::{Dates, Game, IdNameLink, Status, TeamInfo, Teams};
+        let mut cache = NetworkCache::new();
+        let date = test_date();
+
+        // Cache team pages for teams 111 (home), 222 (away), and 333 (uninvolved)
+        for team_id in [111, 222, 333] {
+            cache.insert(
+                CacheKey::TeamPage { team_id, date },
+                NetworkResponse::TeamPageLoaded {
+                    team_id,
+                    date,
+                    schedule: Arc::new(mlbt_api::schedule::ScheduleResponse::default()),
+                    roster: Arc::new(mlbt_api::team::RosterResponse::default()),
+                    transactions: Arc::new(mlbt_api::team::TransactionsResponse::default()),
+                },
+            );
+        }
+
+        // Build a schedule with a Live game between teams 111 and 222
+        let make_game = |state| Game {
+            game_pk: 1,
+            status: Status {
+                abstract_game_state: Some(state),
+                ..Default::default()
+            },
+            teams: Teams {
+                home: TeamInfo {
+                    team: IdNameLink {
+                        id: 111,
+                        ..Default::default()
+                    },
+                    ..Default::default()
+                },
+                away: TeamInfo {
+                    team: IdNameLink {
+                        id: 222,
+                        ..Default::default()
+                    },
+                    ..Default::default()
+                },
+            },
+            ..Default::default()
+        };
+        let schedule = ScheduleResponse {
+            dates: vec![Dates {
+                date: Some(TEST_DATE.to_string()),
+                games: Some(vec![make_game(AbstractGameState::Live)]),
+                ..Default::default()
+            }],
+            ..Default::default()
+        };
+        cache.update_game_states(date, &schedule);
+
+        // Now the game goes Final
+        let schedule = ScheduleResponse {
+            dates: vec![Dates {
+                date: Some(TEST_DATE.to_string()),
+                games: Some(vec![make_game(AbstractGameState::Final)]),
+                ..Default::default()
+            }],
+            ..Default::default()
+        };
+        cache.update_game_states(date, &schedule);
+
+        // Involved teams invalidated, uninvolved preserved
+        assert!(
+            cache
+                .get(&CacheKey::TeamPage { team_id: 111, date })
+                .is_none()
+        );
+        assert!(
+            cache
+                .get(&CacheKey::TeamPage { team_id: 222, date })
+                .is_none()
+        );
+        assert!(
+            cache
+                .get(&CacheKey::TeamPage { team_id: 333, date })
+                .is_some()
+        );
     }
 }

--- a/src/state/cache.rs
+++ b/src/state/cache.rs
@@ -105,10 +105,7 @@ impl NetworkCache {
     fn ttl_for(&self, key: &CacheKey) -> Duration {
         match key {
             CacheKey::GameData { game_id } => {
-                if matches!(
-                    self.game_states.get(game_id),
-                    Some((AbstractGameState::Final, _))
-                ) {
+                if self.is_final_game(*game_id) {
                     FINAL_GAME_TTL
                 } else {
                     Duration::from_secs(10)
@@ -186,6 +183,14 @@ impl NetworkCache {
             .retain(|_, observed_at| observed_at.elapsed() < PRUNE_AGE);
         let removed = before - self.entries.len();
         debug!("pruned {removed} stale cache entries");
+    }
+
+    /// True if the game's last observed abstract state is `Final`.
+    pub fn is_final_game(&self, game_id: u64) -> bool {
+        matches!(
+            self.game_states.get(&game_id),
+            Some((AbstractGameState::Final, _))
+        )
     }
 
     /// Update tracked game states from a schedule response. When a game we previously observed
@@ -761,5 +766,19 @@ mod tests {
                 .get(&CacheKey::TeamPage { team_id: 333, date })
                 .is_some()
         );
+    }
+
+    #[test]
+    fn is_final_game_reflects_last_observed_state() {
+        let mut cache = NetworkCache::new();
+        assert!(!cache.is_final_game(42));
+
+        let schedule = make_schedule(TEST_DATE, vec![(42, AbstractGameState::Live)]);
+        cache.update_game_states(test_date(), &schedule);
+        assert!(!cache.is_final_game(42));
+
+        let schedule = make_schedule(TEST_DATE, vec![(42, AbstractGameState::Final)]);
+        cache.update_game_states(test_date(), &schedule);
+        assert!(cache.is_final_game(42));
     }
 }

--- a/src/state/cache.rs
+++ b/src/state/cache.rs
@@ -9,7 +9,7 @@ use std::time::{Duration, Instant};
 
 const FINAL_GAME_TTL: Duration = Duration::from_hours(1);
 const PRUNE_AGE: Duration = Duration::from_hours(48);
-const PRUNE_INTERVAL: Duration = Duration::from_hours(2);
+pub const PRUNE_INTERVAL: Duration = Duration::from_hours(2);
 
 /// Cache key identifying a unique API request. PlayerProfile is excluded because it requires
 /// owned data for transformation (StatSplits stores Vec<Split> directly).

--- a/src/state/cache.rs
+++ b/src/state/cache.rs
@@ -1,0 +1,545 @@
+use crate::components::stats::table::StatType;
+use crate::state::messages::{NetworkRequest, NetworkResponse};
+use chrono::NaiveDate;
+use log::debug;
+use mlbt_api::schedule::{AbstractGameState, ScheduleResponse};
+use mlbt_api::team::RosterType;
+use std::collections::HashMap;
+use std::time::{Duration, Instant};
+
+const FINAL_GAME_TTL: Duration = Duration::from_hours(1);
+const PRUNE_AGE: Duration = Duration::from_hours(48);
+const PRUNE_INTERVAL: Duration = Duration::from_hours(2);
+
+/// Cache key identifying a unique API request. PlayerProfile is excluded because it requires
+/// owned data for transformation (StatSplits stores Vec<Split> directly).
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+pub enum CacheKey {
+    Schedule {
+        date: NaiveDate,
+    },
+    GameData {
+        game_id: u64,
+    },
+    Standings {
+        date: NaiveDate,
+    },
+    Stats {
+        date: NaiveDate,
+        stat_type: StatType,
+    },
+    TeamPage {
+        team_id: u16,
+        date: NaiveDate,
+    },
+    TeamRoster {
+        team_id: u16,
+        season: i32,
+        roster_type: RosterType,
+    },
+}
+
+struct CacheEntry {
+    response: NetworkResponse,
+    fetched_at: Instant,
+    ttl: Duration,
+}
+
+impl CacheEntry {
+    fn is_fresh(&self) -> bool {
+        self.fetched_at.elapsed() < self.ttl
+    }
+}
+
+pub struct NetworkCache {
+    entries: HashMap<CacheKey, CacheEntry>,
+    /// Tracks the last known abstract game state per game_id, used to detect transitions to Final.
+    /// The `Instant` records when the state was last observed from a schedule response.
+    game_states: HashMap<u64, (AbstractGameState, Instant)>,
+    last_prune: Instant,
+}
+
+impl NetworkCache {
+    pub fn new() -> Self {
+        Self {
+            entries: HashMap::new(),
+            game_states: HashMap::new(),
+            last_prune: Instant::now(),
+        }
+    }
+
+    /// Map a network request to a cache key. Returns `None` for uncacheable requests (Initialize, PlayerProfile).
+    pub fn key_for(request: &NetworkRequest) -> Option<CacheKey> {
+        match request {
+            NetworkRequest::Schedule { date } => Some(CacheKey::Schedule { date: *date }),
+            NetworkRequest::GameData { game_id } => Some(CacheKey::GameData { game_id: *game_id }),
+            NetworkRequest::Standings { date } => Some(CacheKey::Standings { date: *date }),
+            NetworkRequest::Stats { date, stat_type } => Some(CacheKey::Stats {
+                date: *date,
+                stat_type: *stat_type,
+            }),
+            NetworkRequest::TeamPage { team_id, date } => Some(CacheKey::TeamPage {
+                team_id: *team_id,
+                date: *date,
+            }),
+            NetworkRequest::TeamRoster {
+                team_id,
+                season,
+                roster_type,
+            } => Some(CacheKey::TeamRoster {
+                team_id: *team_id,
+                season: *season,
+                roster_type: *roster_type,
+            }),
+            // Not cached: Initialize is one-shot, PlayerProfile consumes owned data
+            NetworkRequest::Initialize | NetworkRequest::PlayerProfile { .. } => None,
+        }
+    }
+
+    /// Default TTL for a cache key.
+    fn default_ttl(key: &CacheKey) -> Duration {
+        match key {
+            CacheKey::GameData { .. } => Duration::from_secs(10),
+            CacheKey::Schedule { .. } => Duration::from_secs(30),
+            CacheKey::Standings { .. } => Duration::from_secs(1800),
+            CacheKey::Stats { .. } => Duration::from_secs(1800),
+            CacheKey::TeamPage { .. } => Duration::from_secs(600),
+            CacheKey::TeamRoster { .. } => Duration::from_secs(1800),
+        }
+    }
+
+    /// Get a cached response if it exists and is fresh.
+    pub fn get(&self, key: &CacheKey) -> Option<NetworkResponse> {
+        let entry = self.entries.get(key)?;
+        if entry.is_fresh() {
+            debug!("cache hit for {key:?}");
+            Some(entry.response.clone())
+        } else {
+            debug!("cache expired for {key:?}");
+            None
+        }
+    }
+
+    /// Insert a response with the default TTL for its key type. If the response is a schedule,
+    /// automatically updates game state tracking and invalidates affected caches.
+    pub fn insert(&mut self, key: CacheKey, response: NetworkResponse) {
+        let date = match &key {
+            CacheKey::Schedule { date } => Some(*date),
+            _ => None,
+        };
+        let ttl = Self::default_ttl(&key);
+        self.entries.insert(
+            key,
+            CacheEntry {
+                response: response.clone(),
+                fetched_at: Instant::now(),
+                ttl,
+            },
+        );
+        if let Some(date) = date
+            && let NetworkResponse::ScheduleLoaded { schedule } = &response
+        {
+            self.update_game_states(date, schedule);
+        }
+    }
+
+    /// Remove cache entries and game states older than `PRUNE_AGE`.
+    /// Only runs once per `PRUNE_INTERVAL` to avoid unnecessary work.
+    pub fn prune(&mut self) {
+        if self.last_prune.elapsed() < PRUNE_INTERVAL {
+            return;
+        }
+        self.last_prune = Instant::now();
+
+        let before = self.entries.len();
+        self.entries
+            .retain(|_, entry| entry.fetched_at.elapsed() < PRUNE_AGE);
+        self.game_states
+            .retain(|_, (_, observed_at)| observed_at.elapsed() < PRUNE_AGE);
+        let removed = before - self.entries.len();
+        debug!("pruned {removed} stale cache entries");
+    }
+
+    /// Update tracked game states from a schedule response. When any game transitions to Final:
+    /// - Extends that game's cached data TTL to 1 hour (data is now static)
+    /// - Invalidates standings and stats caches for the request date only
+    fn update_game_states(&mut self, date: NaiveDate, schedule: &ScheduleResponse) {
+        let mut any_went_final = false;
+
+        for date_entry in &schedule.dates {
+            let Some(games) = &date_entry.games else {
+                continue;
+            };
+            for game in games {
+                let Some(new_state) = &game.status.abstract_game_state else {
+                    continue;
+                };
+                let game_id = game.game_pk;
+                let was_final = matches!(
+                    self.game_states.get(&game_id),
+                    Some((AbstractGameState::Final, _))
+                );
+                let is_final = matches!(new_state, AbstractGameState::Final);
+
+                if is_final && !was_final {
+                    debug!("game {game_id} went Final, extending cache TTL");
+                    if let Some(entry) = self.entries.get_mut(&CacheKey::GameData { game_id }) {
+                        entry.ttl = FINAL_GAME_TTL;
+                        entry.fetched_at = Instant::now();
+                    }
+                    any_went_final = true;
+                }
+
+                self.game_states
+                    .insert(game_id, (*new_state, Instant::now()));
+            }
+        }
+
+        if any_went_final {
+            debug!("invalidating standings and stats for {date} after game(s) went Final");
+            self.entries.retain(|key, _| match key {
+                CacheKey::Standings { date: d } | CacheKey::Stats { date: d, .. } => *d != date,
+                _ => true,
+            });
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use mlbt_api::client::StatGroup;
+    use mlbt_api::schedule::ScheduleResponse;
+    use mlbt_api::season::GameType;
+    use std::sync::Arc;
+
+    const TEST_DATE: &str = "2026-04-13";
+
+    fn test_date() -> NaiveDate {
+        NaiveDate::from_ymd_opt(2026, 4, 13).unwrap()
+    }
+
+    fn schedule_key() -> CacheKey {
+        CacheKey::Schedule { date: test_date() }
+    }
+
+    fn schedule_response() -> NetworkResponse {
+        NetworkResponse::ScheduleLoaded {
+            schedule: Arc::new(ScheduleResponse::default()),
+        }
+    }
+
+    #[test]
+    fn get_returns_none_for_empty_cache() {
+        let cache = NetworkCache::new();
+        assert!(cache.get(&schedule_key()).is_none());
+    }
+
+    #[test]
+    fn get_returns_cached_response() {
+        let mut cache = NetworkCache::new();
+        cache.insert(schedule_key(), schedule_response());
+        assert!(cache.get(&schedule_key()).is_some());
+    }
+
+    #[test]
+    fn get_returns_none_after_ttl_expires() {
+        let mut cache = NetworkCache::new();
+        let key = schedule_key();
+        // Insert with fetched_at in the past so the TTL has already elapsed
+        cache.entries.insert(
+            key.clone(),
+            CacheEntry {
+                response: schedule_response(),
+                fetched_at: Instant::now() - Duration::from_secs(60),
+                ttl: Duration::from_secs(30),
+            },
+        );
+        assert!(cache.get(&key).is_none());
+    }
+
+    #[test]
+    fn key_for_returns_none_for_initialize() {
+        assert!(NetworkCache::key_for(&NetworkRequest::Initialize).is_none());
+    }
+
+    #[test]
+    fn key_for_returns_none_for_player_profile() {
+        let req = NetworkRequest::PlayerProfile {
+            player_id: 1,
+            group: StatGroup::Hitting,
+            date: NaiveDate::from_ymd_opt(2026, 4, 13).unwrap(),
+            game_type: GameType::RegularSeason,
+        };
+        assert!(NetworkCache::key_for(&req).is_none());
+    }
+
+    fn make_schedule(date: &str, games: Vec<(u64, AbstractGameState)>) -> ScheduleResponse {
+        use mlbt_api::schedule::{Dates, Game, Status};
+        ScheduleResponse {
+            dates: vec![Dates {
+                date: Some(date.to_string()),
+                games: Some(
+                    games
+                        .into_iter()
+                        .map(|(id, state)| Game {
+                            game_pk: id,
+                            status: Status {
+                                abstract_game_state: Some(state),
+                                ..Default::default()
+                            },
+                            ..Default::default()
+                        })
+                        .collect(),
+                ),
+                ..Default::default()
+            }],
+            ..Default::default()
+        }
+    }
+
+    fn game_data_response() -> NetworkResponse {
+        use mlbt_api::live::LiveResponse;
+        use mlbt_api::win_probability::WinProbabilityResponse;
+        NetworkResponse::GameDataLoaded {
+            game: Arc::new(LiveResponse::default()),
+            win_probability: Arc::new(WinProbabilityResponse::default()),
+        }
+    }
+
+    #[test]
+    fn final_game_extends_cache_ttl() {
+        let mut cache = NetworkCache::new();
+        let game_id = 123;
+
+        // Cache game data with default TTL
+        cache.insert(CacheKey::GameData { game_id }, game_data_response());
+        assert_eq!(
+            cache.entries[&CacheKey::GameData { game_id }].ttl,
+            Duration::from_secs(10)
+        );
+
+        // First schedule: game is Live
+        let schedule = make_schedule(TEST_DATE, vec![(game_id, AbstractGameState::Live)]);
+        cache.update_game_states(test_date(), &schedule);
+        assert_eq!(
+            cache.entries[&CacheKey::GameData { game_id }].ttl,
+            Duration::from_secs(10)
+        );
+
+        // Game goes Final
+        let schedule = make_schedule(TEST_DATE, vec![(game_id, AbstractGameState::Final)]);
+        cache.update_game_states(test_date(), &schedule);
+        assert_eq!(
+            cache.entries[&CacheKey::GameData { game_id }].ttl,
+            Duration::from_secs(3600)
+        );
+    }
+
+    #[test]
+    fn final_game_invalidates_standings_and_stats() {
+        let mut cache = NetworkCache::new();
+        let date = NaiveDate::from_ymd_opt(2026, 4, 13).unwrap();
+
+        // Cache standings and stats
+        cache.insert(
+            CacheKey::Standings { date },
+            NetworkResponse::StandingsLoaded {
+                standings: Arc::new(mlbt_api::standings::StandingsResponse::default()),
+            },
+        );
+        cache.insert(
+            CacheKey::Stats {
+                date,
+                stat_type: StatType {
+                    group: StatGroup::Hitting,
+                    team_player: crate::components::stats::table::TeamOrPlayer::Player,
+                },
+            },
+            NetworkResponse::StatsLoaded {
+                stats: Arc::new(mlbt_api::stats::StatsResponse::default()),
+            },
+        );
+        assert!(cache.get(&CacheKey::Standings { date }).is_some());
+
+        // Game goes from Live to Final
+        let schedule = make_schedule(TEST_DATE, vec![(123, AbstractGameState::Live)]);
+        cache.update_game_states(test_date(), &schedule);
+        let schedule = make_schedule(TEST_DATE, vec![(123, AbstractGameState::Final)]);
+        cache.update_game_states(test_date(), &schedule);
+
+        // Standings and stats should be invalidated
+        assert!(cache.get(&CacheKey::Standings { date }).is_none());
+        assert!(
+            cache
+                .get(&CacheKey::Stats {
+                    date,
+                    stat_type: StatType {
+                        group: StatGroup::Hitting,
+                        team_player: crate::components::stats::table::TeamOrPlayer::Player,
+                    },
+                })
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn already_final_game_does_not_re_invalidate() {
+        let mut cache = NetworkCache::new();
+        let date = NaiveDate::from_ymd_opt(2026, 4, 13).unwrap();
+
+        // Game already Final
+        let schedule = make_schedule(TEST_DATE, vec![(123, AbstractGameState::Final)]);
+        cache.update_game_states(test_date(), &schedule);
+
+        // Cache standings after the game went Final
+        cache.insert(
+            CacheKey::Standings { date },
+            NetworkResponse::StandingsLoaded {
+                standings: Arc::new(mlbt_api::standings::StandingsResponse::default()),
+            },
+        );
+
+        // Same schedule again, game is still Final, not a new transition
+        cache.update_game_states(test_date(), &schedule);
+        assert!(cache.get(&CacheKey::Standings { date }).is_some());
+    }
+
+    #[test]
+    fn unknown_to_final_counts_as_transition() {
+        let mut cache = NetworkCache::new();
+        let date = NaiveDate::from_ymd_opt(2026, 4, 13).unwrap();
+
+        cache.insert(
+            CacheKey::Standings { date },
+            NetworkResponse::StandingsLoaded {
+                standings: Arc::new(mlbt_api::standings::StandingsResponse::default()),
+            },
+        );
+
+        // Game appears for the first time as Final (no prior state tracked)
+        let schedule = make_schedule(TEST_DATE, vec![(456, AbstractGameState::Final)]);
+        cache.update_game_states(test_date(), &schedule);
+
+        assert!(cache.get(&CacheKey::Standings { date }).is_none());
+    }
+
+    #[test]
+    fn final_ttl_expires_from_transition_time_not_fetch_time() {
+        let mut cache = NetworkCache::new();
+        let game_id = 789;
+
+        // Insert game data with fetched_at in the past
+        cache.entries.insert(
+            CacheKey::GameData { game_id },
+            CacheEntry {
+                response: game_data_response(),
+                fetched_at: Instant::now() - Duration::from_secs(600),
+                ttl: Duration::from_secs(10),
+            },
+        );
+
+        // Game goes Final — should reset fetched_at to now
+        let schedule = make_schedule(TEST_DATE, vec![(game_id, AbstractGameState::Final)]);
+        cache.update_game_states(test_date(), &schedule);
+
+        let entry = &cache.entries[&CacheKey::GameData { game_id }];
+        assert_eq!(entry.ttl, FINAL_GAME_TTL);
+        assert!(entry.fetched_at.elapsed() < Duration::from_secs(1));
+    }
+
+    #[test]
+    fn prune_removes_old_entries_and_old_game_states() {
+        let mut cache = NetworkCache::new();
+        // Force prune to run immediately
+        cache.last_prune = Instant::now() - PRUNE_INTERVAL;
+
+        // Insert an entry far in the past
+        cache.entries.insert(
+            CacheKey::GameData { game_id: 111 },
+            CacheEntry {
+                response: game_data_response(),
+                fetched_at: Instant::now() - PRUNE_AGE - Duration::from_secs(1),
+                ttl: Duration::from_hours(1),
+            },
+        );
+        cache
+            .game_states
+            .insert(111, (AbstractGameState::Final, Instant::now() - PRUNE_AGE));
+
+        // Insert a fresh entry
+        cache.insert(CacheKey::GameData { game_id: 222 }, game_data_response());
+        cache
+            .game_states
+            .insert(222, (AbstractGameState::Live, Instant::now()));
+
+        cache.prune();
+
+        assert!(
+            !cache
+                .entries
+                .contains_key(&CacheKey::GameData { game_id: 111 })
+        );
+        assert!(!cache.game_states.contains_key(&111));
+        assert!(
+            cache
+                .entries
+                .contains_key(&CacheKey::GameData { game_id: 222 })
+        );
+        assert!(cache.game_states.contains_key(&222));
+    }
+
+    #[test]
+    fn prune_skips_when_interval_not_elapsed() {
+        let mut cache = NetworkCache::new();
+
+        // Insert an old entry
+        cache.entries.insert(
+            CacheKey::GameData { game_id: 111 },
+            CacheEntry {
+                response: game_data_response(),
+                fetched_at: Instant::now() - PRUNE_AGE - Duration::from_secs(1),
+                ttl: Duration::from_hours(1),
+            },
+        );
+
+        // Prune should be a no-op since last_prune is recent
+        cache.prune();
+        assert!(
+            cache
+                .entries
+                .contains_key(&CacheKey::GameData { game_id: 111 })
+        );
+    }
+
+    #[test]
+    fn final_on_one_date_does_not_invalidate_other_dates() {
+        let mut cache = NetworkCache::new();
+        let apr13 = NaiveDate::from_ymd_opt(2026, 4, 13).unwrap();
+        let apr10 = NaiveDate::from_ymd_opt(2026, 4, 10).unwrap();
+
+        // Cache standings for both dates
+        cache.insert(
+            CacheKey::Standings { date: apr13 },
+            NetworkResponse::StandingsLoaded {
+                standings: Arc::new(mlbt_api::standings::StandingsResponse::default()),
+            },
+        );
+        cache.insert(
+            CacheKey::Standings { date: apr10 },
+            NetworkResponse::StandingsLoaded {
+                standings: Arc::new(mlbt_api::standings::StandingsResponse::default()),
+            },
+        );
+
+        // Game on Apr 13 goes Final
+        let schedule = make_schedule(TEST_DATE, vec![(123, AbstractGameState::Live)]);
+        cache.update_game_states(test_date(), &schedule);
+        let schedule = make_schedule(TEST_DATE, vec![(123, AbstractGameState::Final)]);
+        cache.update_game_states(test_date(), &schedule);
+
+        // Apr 13 standings invalidated, Apr 10 standings preserved
+        assert!(cache.get(&CacheKey::Standings { date: apr13 }).is_none());
+        assert!(cache.get(&CacheKey::Standings { date: apr10 }).is_some());
+    }
+}

--- a/src/state/cache.rs
+++ b/src/state/cache.rs
@@ -96,10 +96,19 @@ impl NetworkCache {
         }
     }
 
-    /// Default TTL for a cache key.
-    fn default_ttl(key: &CacheKey) -> Duration {
+    /// TTL for a cache key. Final games get an extended TTL since their data is static.
+    fn ttl_for(&self, key: &CacheKey) -> Duration {
         match key {
-            CacheKey::GameData { .. } => Duration::from_secs(10),
+            CacheKey::GameData { game_id } => {
+                if matches!(
+                    self.game_states.get(game_id),
+                    Some((AbstractGameState::Final, _))
+                ) {
+                    FINAL_GAME_TTL
+                } else {
+                    Duration::from_secs(10)
+                }
+            }
             CacheKey::Schedule { .. } => Duration::from_secs(30),
             CacheKey::Standings { .. } => Duration::from_secs(1800),
             CacheKey::Stats { .. } => Duration::from_secs(1800),
@@ -127,7 +136,7 @@ impl NetworkCache {
             CacheKey::Schedule { date } => Some(*date),
             _ => None,
         };
-        let ttl = Self::default_ttl(&key);
+        let ttl = self.ttl_for(&key);
         self.entries.insert(
             key,
             CacheEntry {
@@ -141,6 +150,11 @@ impl NetworkCache {
         {
             self.update_game_states(date, schedule);
         }
+    }
+
+    /// Remove a cache entry, forcing the next request to fetch from the API.
+    pub fn invalidate(&mut self, key: &CacheKey) {
+        self.entries.remove(key);
     }
 
     /// Remove cache entries and game states older than `PRUNE_AGE`.

--- a/src/state/gameday.rs
+++ b/src/state/gameday.rs
@@ -1,4 +1,5 @@
 use crate::components::game::live_game::GameState;
+use mlbt_api::schedule::AbstractGameState;
 
 #[derive(Default)]
 pub struct GamedayState {
@@ -14,6 +15,13 @@ impl GamedayState {
 
     pub fn current_game_id(&self) -> u64 {
         self.game.game_id
+    }
+
+    pub fn is_final(&self) -> bool {
+        matches!(
+            self.game.abstract_game_state,
+            Some(AbstractGameState::Final)
+        )
     }
 
     pub fn reset(&mut self, game_id: Option<u64>) {

--- a/src/state/messages.rs
+++ b/src/state/messages.rs
@@ -13,7 +13,7 @@ use mlbt_api::team::{RosterResponse, RosterType, TransactionsResponse};
 use mlbt_api::win_probability::WinProbabilityResponse;
 use std::sync::Arc;
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Copy, Clone)]
 pub enum NetworkRequest {
     Initialize,
     Schedule {
@@ -44,6 +44,31 @@ pub enum NetworkRequest {
         season: i32,
         roster_type: RosterType,
     },
+}
+
+/// Wrapper that pairs a request with a force_refresh flag for the cache layer.
+#[derive(Debug, Copy, Clone)]
+pub struct RefreshableRequest {
+    pub request: NetworkRequest,
+    pub force_refresh: bool,
+}
+
+impl RefreshableRequest {
+    pub fn force(request: NetworkRequest) -> Self {
+        Self {
+            request,
+            force_refresh: true,
+        }
+    }
+}
+
+impl From<NetworkRequest> for RefreshableRequest {
+    fn from(request: NetworkRequest) -> Self {
+        Self {
+            request,
+            force_refresh: false,
+        }
+    }
 }
 
 #[derive(Clone, Debug)]

--- a/src/state/messages.rs
+++ b/src/state/messages.rs
@@ -54,6 +54,13 @@ pub struct RefreshableRequest {
 }
 
 impl RefreshableRequest {
+    pub fn new(request: NetworkRequest, force_refresh: bool) -> Self {
+        Self {
+            request,
+            force_refresh,
+        }
+    }
+
     pub fn force(request: NetworkRequest) -> Self {
         Self {
             request,

--- a/src/state/messages.rs
+++ b/src/state/messages.rs
@@ -11,6 +11,7 @@ use mlbt_api::standings::StandingsResponse;
 use mlbt_api::stats::StatsResponse;
 use mlbt_api::team::{RosterResponse, RosterType, TransactionsResponse};
 use mlbt_api::win_probability::WinProbabilityResponse;
+use std::sync::Arc;
 
 #[derive(Debug, Clone)]
 pub enum NetworkRequest {
@@ -45,38 +46,38 @@ pub enum NetworkRequest {
     },
 }
 
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub enum NetworkResponse {
     LoadingStateChanged {
         loading_state: LoadingState,
     },
     ScheduleLoaded {
-        schedule: ScheduleResponse,
+        schedule: Arc<ScheduleResponse>,
     },
     GameDataLoaded {
-        game: Box<LiveResponse>,
-        win_probability: WinProbabilityResponse,
+        game: Arc<LiveResponse>,
+        win_probability: Arc<WinProbabilityResponse>,
     },
     StandingsLoaded {
-        standings: StandingsResponse,
+        standings: Arc<StandingsResponse>,
     },
     StatsLoaded {
-        stats: StatsResponse,
+        stats: Arc<StatsResponse>,
     },
     PlayerProfileLoaded {
-        data: PeopleResponse,
+        data: Arc<PeopleResponse>,
         game_type: GameType,
     },
     TeamPageLoaded {
         team_id: u16,
         date: NaiveDate,
-        schedule: ScheduleResponse,
-        roster: RosterResponse,
-        transactions: TransactionsResponse,
+        schedule: Arc<ScheduleResponse>,
+        roster: Arc<RosterResponse>,
+        transactions: Arc<TransactionsResponse>,
     },
     TeamRosterLoaded {
         team_id: u16,
-        roster: RosterResponse,
+        roster: Arc<RosterResponse>,
         roster_type: RosterType,
     },
     Initialized,

--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -1,6 +1,7 @@
 pub mod app_settings;
 pub mod app_state;
 pub mod boxscore;
+pub mod cache;
 pub mod date_input;
 pub mod gameday;
 pub mod messages;

--- a/src/state/network.rs
+++ b/src/state/network.rs
@@ -1,7 +1,7 @@
 use crate::components::constants::register_teams;
 use crate::components::stats::table::{StatType, TeamOrPlayer};
 use crate::state::cache::NetworkCache;
-use crate::{NetworkRequest, NetworkResponse};
+use crate::state::messages::{NetworkRequest, NetworkResponse, RefreshableRequest};
 use chrono::{Datelike, NaiveDate};
 use log::{debug, error, warn};
 use mlbt_api::client::{ApiResult, MLBApi, MLBApiBuilder, StatGroup};
@@ -33,7 +33,7 @@ impl Default for LoadingState {
 
 pub struct NetworkWorker {
     client: MLBApi,
-    requests: mpsc::Receiver<NetworkRequest>,
+    requests: mpsc::Receiver<RefreshableRequest>,
     responses: mpsc::Sender<NetworkResponse>,
     is_loading: Arc<AtomicBool>,
     /// Cached season info, keyed by year.
@@ -43,7 +43,7 @@ pub struct NetworkWorker {
 
 impl NetworkWorker {
     pub fn new(
-        requests: mpsc::Receiver<NetworkRequest>,
+        requests: mpsc::Receiver<RefreshableRequest>,
         responses: mpsc::Sender<NetworkResponse>,
     ) -> Self {
         Self {
@@ -57,9 +57,18 @@ impl NetworkWorker {
     }
 
     pub async fn run(mut self) {
-        while let Some(request) = self.requests.recv().await {
-            // Check cache before making API calls
+        while let Some(refreshable) = self.requests.recv().await {
+            let request = refreshable.request;
             let cache_key = NetworkCache::key_for(&request);
+
+            // Force refresh invalidates so the cache check below misses
+            if refreshable.force_refresh
+                && let Some(key) = cache_key.as_ref()
+            {
+                self.cache.invalidate(key);
+            }
+
+            // Check cache before making API calls
             if let Some(key) = cache_key.as_ref()
                 && let Some(cached) = self.cache.get(key)
             {

--- a/src/state/network.rs
+++ b/src/state/network.rs
@@ -1,5 +1,6 @@
 use crate::components::constants::register_teams;
 use crate::components::stats::table::{StatType, TeamOrPlayer};
+use crate::state::cache::NetworkCache;
 use crate::{NetworkRequest, NetworkResponse};
 use chrono::{Datelike, NaiveDate};
 use log::{debug, error, warn};
@@ -37,6 +38,7 @@ pub struct NetworkWorker {
     is_loading: Arc<AtomicBool>,
     /// Cached season info, keyed by year.
     season_info: Option<(i32, SeasonInfo)>,
+    cache: NetworkCache,
 }
 
 impl NetworkWorker {
@@ -50,11 +52,24 @@ impl NetworkWorker {
             responses,
             is_loading: Arc::new(AtomicBool::new(false)),
             season_info: None,
+            cache: NetworkCache::new(),
         }
     }
 
     pub async fn run(mut self) {
         while let Some(request) = self.requests.recv().await {
+            // Check cache before making API calls
+            let cache_key = NetworkCache::key_for(&request);
+            if let Some(key) = cache_key.as_ref()
+                && let Some(cached) = self.cache.get(key)
+            {
+                if let Err(e) = self.responses.send(cached).await {
+                    error!("Failed to send cached response: {e}");
+                    break;
+                }
+                continue;
+            }
+
             self.start_loading_animation().await;
             let result = match request {
                 NetworkRequest::Initialize => self.handle_initialize().await,
@@ -88,19 +103,31 @@ impl NetworkWorker {
             debug!("request complete");
             self.stop_loading_animation(result.is_ok()).await;
 
+            // Cache successful responses
+            if let Ok(ref response) = result
+                && let Some(key) = cache_key
+            {
+                self.cache.insert(key, response.clone());
+            }
+
             let response =
                 result.unwrap_or_else(|err| NetworkResponse::Error { message: err.log() });
             if let Err(e) = self.responses.send(response).await {
                 error!("Failed to send network response: {e}");
                 break;
             }
+
+            // TODO use tokio::select! to handle prune
+            self.cache.prune();
         }
     }
 
     async fn handle_load_schedule(&self, date: NaiveDate) -> ApiResult<NetworkResponse> {
         debug!("loading schedule for {date}");
         let schedule = self.client.get_schedule_date(date).await?;
-        Ok(NetworkResponse::ScheduleLoaded { schedule })
+        Ok(NetworkResponse::ScheduleLoaded {
+            schedule: Arc::new(schedule),
+        })
     }
 
     async fn handle_load_game_data(&self, game_id: u64) -> ApiResult<NetworkResponse> {
@@ -110,8 +137,8 @@ impl NetworkWorker {
             self.client.get_win_probability(game_id),
         );
         Ok(NetworkResponse::GameDataLoaded {
-            game: Box::new(game?),
-            win_probability: wp?,
+            game: Arc::new(game?),
+            win_probability: Arc::new(wp?),
         })
     }
 
@@ -120,7 +147,9 @@ impl NetworkWorker {
         self.ensure_season_info(date).await;
         let game_type = game_type_for_date(date, self.cached_season_info());
         let standings = self.client.get_standings(date, game_type).await?;
-        Ok(NetworkResponse::StandingsLoaded { standings })
+        Ok(NetworkResponse::StandingsLoaded {
+            standings: Arc::new(standings),
+        })
     }
 
     async fn handle_load_stats(
@@ -144,7 +173,9 @@ impl NetworkWorker {
                     .await
             }
         }?;
-        Ok(NetworkResponse::StatsLoaded { stats })
+        Ok(NetworkResponse::StatsLoaded {
+            stats: Arc::new(stats),
+        })
     }
 
     async fn handle_load_player_profile(
@@ -159,7 +190,10 @@ impl NetworkWorker {
             .client
             .get_player_profile(player_id, group, date.year(), game_type)
             .await?;
-        Ok(NetworkResponse::PlayerProfileLoaded { data, game_type })
+        Ok(NetworkResponse::PlayerProfileLoaded {
+            data: Arc::new(data),
+            game_type,
+        })
     }
 
     async fn handle_load_team_page(
@@ -178,9 +212,9 @@ impl NetworkWorker {
         Ok(NetworkResponse::TeamPageLoaded {
             team_id,
             date,
-            schedule,
-            roster,
-            transactions,
+            schedule: Arc::new(schedule),
+            roster: Arc::new(roster),
+            transactions: Arc::new(transactions),
         })
     }
 
@@ -197,7 +231,7 @@ impl NetworkWorker {
             .await?;
         Ok(NetworkResponse::TeamRosterLoaded {
             team_id,
-            roster,
+            roster: Arc::new(roster),
             roster_type,
         })
     }

--- a/src/state/network.rs
+++ b/src/state/network.rs
@@ -81,6 +81,15 @@ impl NetworkWorker {
                         refreshable.request = NetworkRequest::GameData { game_id: latest };
                     }
 
+                    // The primary request cancels any pending debounce when it's not a new
+                    // debounceable GameData. Overflow items don't as they arrived earlier in time.
+                    let is_debounceable_game =
+                        matches!(refreshable.request, NetworkRequest::GameData { .. })
+                            && !refreshable.force_refresh;
+                    if !is_debounceable_game {
+                        debounce_game_id = None;
+                    }
+
                     self.handle_request(refreshable, &mut debounce_game_id, debounce_sleep.as_mut()).await;
 
                     // Process any non-GameData requests collected during draining
@@ -135,11 +144,6 @@ impl NetworkWorker {
             && let Some(key) = cache_key.as_ref()
         {
             self.cache.invalidate(key);
-        }
-
-        // Any non-debounced request cancels a pending debounce
-        if !matches!(request, NetworkRequest::GameData { .. }) || refreshable.force_refresh {
-            *debounce_game_id = None;
         }
 
         // Check cache before making API calls

--- a/src/state/network.rs
+++ b/src/state/network.rs
@@ -1,6 +1,6 @@
 use crate::components::constants::register_teams;
 use crate::components::stats::table::{StatType, TeamOrPlayer};
-use crate::state::cache::NetworkCache;
+use crate::state::cache::{NetworkCache, PRUNE_INTERVAL};
 use crate::state::messages::{NetworkRequest, NetworkResponse, RefreshableRequest};
 use chrono::{Datelike, NaiveDate};
 use log::{debug, error, warn};
@@ -8,11 +8,13 @@ use mlbt_api::client::{ApiResult, MLBApi, MLBApiBuilder, StatGroup};
 use mlbt_api::season::{SeasonInfo, game_type_for_date};
 use mlbt_api::team::RosterType;
 use mlbt_api::teams::SportId;
+use std::pin::Pin;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::Duration;
 use tokio::sync::mpsc;
 
+const DEBOUNCE_DELAY: Duration = Duration::from_millis(250);
 const SPINNER_CHARS: [char; 10] = ['⠋', '⠙', '⠹', '⠸', '⠼', '⠴', '⠦', '⠧', '⠇', '⠏'];
 pub const ERROR_CHAR: char = '!';
 
@@ -57,77 +59,158 @@ impl NetworkWorker {
     }
 
     pub async fn run(mut self) {
-        while let Some(refreshable) = self.requests.recv().await {
-            let request = refreshable.request;
-            let cache_key = NetworkCache::key_for(&request);
+        let debounce_sleep = tokio::time::sleep(DEBOUNCE_DELAY);
+        tokio::pin!(debounce_sleep);
 
-            // Force refresh invalidates so the cache check below misses
-            if refreshable.force_refresh
-                && let Some(key) = cache_key.as_ref()
-            {
-                self.cache.invalidate(key);
+        let mut debounce_game_id: Option<u64> = None;
+        let mut prune_interval = tokio::time::interval(PRUNE_INTERVAL);
+        prune_interval.tick().await; // consume the immediate first tick
+
+        let mut overflow: Vec<RefreshableRequest> = Vec::new();
+
+        loop {
+            tokio::select! {
+                msg = self.requests.recv() => {
+                    let Some(mut refreshable) = msg else { break };
+
+                    // Coalesce: if this is a debounced GameData, drain queued ones
+                    if let NetworkRequest::GameData { game_id } = refreshable.request
+                        && !refreshable.force_refresh
+                    {
+                        let latest = self.drain_game_data(game_id, &mut overflow);
+                        refreshable.request = NetworkRequest::GameData { game_id: latest };
+                    }
+
+                    self.handle_request(refreshable, &mut debounce_game_id, debounce_sleep.as_mut()).await;
+
+                    // Process any non-GameData requests collected during draining
+                    for req in overflow.drain(..) {
+                        self.handle_request(req, &mut debounce_game_id, debounce_sleep.as_mut()).await;
+                    }
+                }
+                () = &mut debounce_sleep, if debounce_game_id.is_some() => {
+                    // Drain any last-moment queued GameData requests
+                    let game_id = self.drain_game_data(debounce_game_id.take().unwrap(), &mut overflow);
+                    self.fetch_and_send(NetworkRequest::GameData { game_id }).await;
+
+                    for req in overflow.drain(..) {
+                        self.handle_request(req, &mut debounce_game_id, debounce_sleep.as_mut()).await;
+                    }
+                }
+                _ = prune_interval.tick() => {
+                    self.cache.prune();
+                }
             }
+        }
+    }
 
-            // Check cache before making API calls
-            if let Some(key) = cache_key.as_ref()
-                && let Some(cached) = self.cache.get(key)
-            {
-                if let Err(e) = self.responses.send(cached).await {
-                    error!("Failed to send cached response: {e}");
-                    break;
+    /// Drain queued `GameData` requests from the channel and return the latest game_id.
+    /// Non-`GameData` requests encountered during draining are collected for later processing.
+    /// This coalesces across intervening non-game requests, which can reorder them.
+    fn drain_game_data(&mut self, mut game_id: u64, overflow: &mut Vec<RefreshableRequest>) -> u64 {
+        while let Ok(next) = self.requests.try_recv() {
+            match next.request {
+                NetworkRequest::GameData {
+                    game_id: new_game_id,
+                } if !next.force_refresh => {
+                    game_id = new_game_id;
                 }
-                continue;
+                _ => overflow.push(next),
             }
+        }
+        game_id
+    }
 
-            self.start_loading_animation().await;
-            let result = match request {
-                NetworkRequest::Initialize => self.handle_initialize().await,
-                NetworkRequest::Schedule { date } => self.handle_load_schedule(date).await,
-                NetworkRequest::GameData { game_id } => self.handle_load_game_data(game_id).await,
-                NetworkRequest::Standings { date } => self.handle_load_standings(date).await,
-                NetworkRequest::Stats { date, stat_type } => {
-                    self.handle_load_stats(date, stat_type).await
-                }
-                NetworkRequest::PlayerProfile {
-                    player_id,
-                    group,
-                    date,
-                    game_type,
-                } => {
-                    self.handle_load_player_profile(player_id, group, date, game_type)
-                        .await
-                }
-                NetworkRequest::TeamPage { team_id, date } => {
-                    self.handle_load_team_page(team_id, date).await
-                }
-                NetworkRequest::TeamRoster {
-                    team_id,
-                    season,
-                    roster_type,
-                } => {
-                    self.handle_load_team_roster(team_id, season, roster_type)
-                        .await
-                }
-            };
-            debug!("request complete");
-            self.stop_loading_animation(result.is_ok()).await;
+    async fn handle_request(
+        &mut self,
+        refreshable: RefreshableRequest,
+        debounce_game_id: &mut Option<u64>,
+        mut debounce_sleep: Pin<&mut tokio::time::Sleep>,
+    ) {
+        let request = refreshable.request;
+        let cache_key = NetworkCache::key_for(&request);
 
-            // Cache successful responses
-            if let Ok(ref response) = result
-                && let Some(key) = cache_key
-            {
-                self.cache.insert(key, response.clone());
+        // Force refresh invalidates so the cache check below misses
+        if refreshable.force_refresh
+            && let Some(key) = cache_key.as_ref()
+        {
+            self.cache.invalidate(key);
+        }
+
+        // Any non-debounced request cancels a pending debounce
+        if !matches!(request, NetworkRequest::GameData { .. }) || refreshable.force_refresh {
+            *debounce_game_id = None;
+        }
+
+        // Check cache before making API calls
+        if let Some(key) = cache_key.as_ref()
+            && let Some(cached) = self.cache.get(key)
+        {
+            let _ = self.responses.send(cached).await;
+            return;
+        }
+
+        // Debounce game data requests (unless force refresh)
+        if let NetworkRequest::GameData { game_id } = request
+            && !refreshable.force_refresh
+        {
+            debug!("debouncing game data request for {game_id}");
+            *debounce_game_id = Some(game_id);
+            debounce_sleep
+                .as_mut()
+                .reset(tokio::time::Instant::now() + DEBOUNCE_DELAY);
+            return;
+        }
+
+        self.fetch_and_send(request).await;
+    }
+
+    async fn fetch_and_send(&mut self, request: NetworkRequest) {
+        let cache_key = NetworkCache::key_for(&request);
+
+        self.start_loading_animation().await;
+        let result = match request {
+            NetworkRequest::Initialize => self.handle_initialize().await,
+            NetworkRequest::Schedule { date } => self.handle_load_schedule(date).await,
+            NetworkRequest::GameData { game_id } => self.handle_load_game_data(game_id).await,
+            NetworkRequest::Standings { date } => self.handle_load_standings(date).await,
+            NetworkRequest::Stats { date, stat_type } => {
+                self.handle_load_stats(date, stat_type).await
             }
-
-            let response =
-                result.unwrap_or_else(|err| NetworkResponse::Error { message: err.log() });
-            if let Err(e) = self.responses.send(response).await {
-                error!("Failed to send network response: {e}");
-                break;
+            NetworkRequest::PlayerProfile {
+                player_id,
+                group,
+                date,
+                game_type,
+            } => {
+                self.handle_load_player_profile(player_id, group, date, game_type)
+                    .await
             }
+            NetworkRequest::TeamPage { team_id, date } => {
+                self.handle_load_team_page(team_id, date).await
+            }
+            NetworkRequest::TeamRoster {
+                team_id,
+                season,
+                roster_type,
+            } => {
+                self.handle_load_team_roster(team_id, season, roster_type)
+                    .await
+            }
+        };
+        debug!("request complete");
+        self.stop_loading_animation(result.is_ok()).await;
 
-            // TODO use tokio::select! to handle prune
-            self.cache.prune();
+        // Cache successful responses
+        if let Ok(ref response) = result
+            && let Some(key) = cache_key
+        {
+            self.cache.insert(key, response.clone());
+        }
+
+        let response = result.unwrap_or_else(|err| NetworkResponse::Error { message: err.log() });
+        if let Err(e) = self.responses.send(response).await {
+            error!("Failed to send network response: {e}");
         }
     }
 
@@ -348,5 +431,99 @@ impl NetworkWorker {
             .responses
             .send(NetworkResponse::LoadingStateChanged { loading_state })
             .await;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::NaiveDate;
+
+    fn worker() -> NetworkWorker {
+        let (_request_tx, request_rx) = mpsc::channel(32);
+        let (response_tx, _response_rx) = mpsc::channel(32);
+        NetworkWorker::new(request_rx, response_tx)
+    }
+
+    fn game_request(game_id: u64) -> RefreshableRequest {
+        RefreshableRequest {
+            request: NetworkRequest::GameData { game_id },
+            force_refresh: false,
+        }
+    }
+
+    fn force_refresh_game_request(game_id: u64) -> RefreshableRequest {
+        RefreshableRequest {
+            request: NetworkRequest::GameData { game_id },
+            force_refresh: true,
+        }
+    }
+
+    fn schedule_request(date: NaiveDate) -> RefreshableRequest {
+        RefreshableRequest {
+            request: NetworkRequest::Schedule { date },
+            force_refresh: false,
+        }
+    }
+
+    #[test]
+    fn drain_game_data_returns_latest_game_id_from_burst() {
+        let mut worker = worker();
+        let (tx, rx) = mpsc::channel(32);
+        worker.requests = rx;
+        let mut overflow = Vec::new();
+
+        tx.try_send(game_request(2)).unwrap();
+        tx.try_send(game_request(3)).unwrap();
+        tx.try_send(game_request(4)).unwrap();
+
+        let latest = worker.drain_game_data(1, &mut overflow);
+
+        assert_eq!(latest, 4);
+        assert!(overflow.is_empty());
+    }
+
+    #[test]
+    fn drain_game_data_preserves_non_game_requests_in_overflow() {
+        let mut worker = worker();
+        let (tx, rx) = mpsc::channel(32);
+        worker.requests = rx;
+        let mut overflow = Vec::new();
+        let date = NaiveDate::from_ymd_opt(2025, 4, 13).unwrap();
+
+        tx.try_send(schedule_request(date)).unwrap();
+        tx.try_send(game_request(9)).unwrap();
+
+        let latest = worker.drain_game_data(7, &mut overflow);
+
+        assert_eq!(latest, 9);
+        assert_eq!(overflow.len(), 1);
+        assert!(matches!(
+            overflow[0].request,
+            NetworkRequest::Schedule { date: d } if d == date
+        ));
+    }
+
+    #[test]
+    fn drain_game_data_does_not_coalesce_force_refresh_game_requests() {
+        let mut worker = worker();
+        let (tx, rx) = mpsc::channel(32);
+        worker.requests = rx;
+        let mut overflow = Vec::new();
+
+        tx.try_send(force_refresh_game_request(99)).unwrap();
+        tx.try_send(game_request(42)).unwrap();
+
+        let latest = worker.drain_game_data(1, &mut overflow);
+
+        assert_eq!(latest, 42);
+        assert_eq!(overflow.len(), 1);
+        assert!(matches!(
+            overflow[0],
+            RefreshableRequest {
+                request: NetworkRequest::GameData { game_id: 99 },
+                force_refresh: true,
+            }
+        ));
     }
 }

--- a/src/state/player_profile.rs
+++ b/src/state/player_profile.rs
@@ -3,6 +3,7 @@ use crate::state::messages::NetworkRequest;
 use mlbt_api::client::StatGroup;
 use mlbt_api::player::PeopleResponse;
 use mlbt_api::season::GameType;
+use std::sync::Arc;
 use tui::widgets::ScrollbarState;
 
 /// State for a single Player Profile view.
@@ -19,13 +20,17 @@ pub struct PlayerProfileState {
 
 impl PlayerProfileState {
     /// Create from an api response. Returns None if the response has no player data.
+    ///
+    /// Takes `Arc<PeopleResponse>` and unwraps to get ownership. Player profiles are not cached,
+    /// so the Arc refcount should always be 1 here.
     pub fn from_response(
-        data: PeopleResponse,
+        data: Arc<PeopleResponse>,
         stat_group: StatGroup,
         game_type: GameType,
         season_year: i32,
     ) -> Option<Self> {
         // only one player was requested so there should only be one person in the response vec.
+        let data = Arc::try_unwrap(data).ok()?;
         let person = data.people.into_iter().next()?;
         Some(Self {
             profile: PlayerProfile::from_person(person),

--- a/src/state/refresher.rs
+++ b/src/state/refresher.rs
@@ -23,13 +23,17 @@ impl PeriodicRefresher {
             tokio::select! {
                 // Live game data updates (frequent for active games)
                 _ = live_interval.tick() => {
-                    let (active_tab, game_id) = {
+                    let (active_tab, game_id, is_final) = {
                         let app = app.lock().await;
-                        (app.state.active_tab, app.state.gameday.current_game_id())
+                        (
+                            app.state.active_tab,
+                            app.state.gameday.current_game_id(),
+                            app.state.gameday.is_final(),
+                        )
                     };
 
-                    if active_tab == MenuItem::Gameday && game_id > 0 {
-                        let _ = self.network_requests.send(NetworkRequest::GameData { game_id }.into()).await;
+                    if active_tab == MenuItem::Gameday && game_id > 0 && !is_final {
+                        let _ = self.network_requests.send(RefreshableRequest::force(NetworkRequest::GameData { game_id })).await;
                     }
                 }
 
@@ -41,9 +45,9 @@ impl PeriodicRefresher {
                     };
 
                     if active_tab == MenuItem::Scoreboard {
-                        let _ = self.network_requests.send(NetworkRequest::Schedule { date }.into()).await;
+                        let _ = self.network_requests.send(RefreshableRequest::force(NetworkRequest::Schedule { date })).await;
                         if game_id > 0 {
-                            let _ = self.network_requests.send(NetworkRequest::GameData { game_id }.into()).await;
+                            let _ = self.network_requests.send(RefreshableRequest::force(NetworkRequest::GameData { game_id })).await;
                         }
                     }
                 }
@@ -56,7 +60,7 @@ impl PeriodicRefresher {
                     };
 
                     if active_tab == MenuItem::Standings {
-                        let _ = self.network_requests.send(NetworkRequest::Standings { date }.into()).await;
+                        let _ = self.network_requests.send(RefreshableRequest::force(NetworkRequest::Standings { date })).await;
                     }
                 }
 
@@ -68,7 +72,7 @@ impl PeriodicRefresher {
                     };
 
                     if active_tab == MenuItem::Stats {
-                        let _ = self.network_requests.send(NetworkRequest::Stats { date, stat_type }.into()).await;
+                        let _ = self.network_requests.send(RefreshableRequest::force(NetworkRequest::Stats { date, stat_type })).await;
                     }
                 }
             }

--- a/src/state/refresher.rs
+++ b/src/state/refresher.rs
@@ -15,8 +15,9 @@ impl PeriodicRefresher {
 
     pub async fn run(self, app: std::sync::Arc<tokio::sync::Mutex<App>>) {
         let mut live_interval = interval(Duration::from_secs(10)); // Live data every 10s
-        let mut schedule_interval = interval(Duration::from_secs(60)); // Schedule every minute
+        let mut schedule_interval = interval(Duration::from_secs(30)); // Schedule every 30s
         let mut standings_interval = interval(Duration::from_secs(1800)); // Standings every 30 minutes
+        let mut stats_interval = interval(Duration::from_secs(1800)); // Stats every 30 minutes
 
         loop {
             tokio::select! {
@@ -56,6 +57,18 @@ impl PeriodicRefresher {
 
                     if active_tab == MenuItem::Standings {
                         let _ = self.network_requests.send(NetworkRequest::Standings { date }).await;
+                    }
+                }
+
+                // Stats updates (low frequency)
+                _ = stats_interval.tick() => {
+                    let (active_tab, date, stat_type) = {
+                        let app = app.lock().await;
+                        (app.state.active_tab, app.state.stats.date_selector.date, app.state.stats.stat_type)
+                    };
+
+                    if active_tab == MenuItem::Stats {
+                        let _ = self.network_requests.send(NetworkRequest::Stats { date, stat_type }).await;
                     }
                 }
             }

--- a/src/state/refresher.rs
+++ b/src/state/refresher.rs
@@ -1,15 +1,15 @@
-use crate::NetworkRequest;
 use crate::app::{App, MenuItem};
+use crate::state::messages::{NetworkRequest, RefreshableRequest};
 use std::time::Duration;
 use tokio::sync::mpsc;
 use tokio::time::interval;
 
 pub struct PeriodicRefresher {
-    network_requests: mpsc::Sender<NetworkRequest>,
+    network_requests: mpsc::Sender<RefreshableRequest>,
 }
 
 impl PeriodicRefresher {
-    pub fn new(network_requests: mpsc::Sender<NetworkRequest>) -> Self {
+    pub fn new(network_requests: mpsc::Sender<RefreshableRequest>) -> Self {
         Self { network_requests }
     }
 
@@ -29,7 +29,7 @@ impl PeriodicRefresher {
                     };
 
                     if active_tab == MenuItem::Gameday && game_id > 0 {
-                        let _ = self.network_requests.send(NetworkRequest::GameData { game_id }).await;
+                        let _ = self.network_requests.send(NetworkRequest::GameData { game_id }.into()).await;
                     }
                 }
 
@@ -41,9 +41,9 @@ impl PeriodicRefresher {
                     };
 
                     if active_tab == MenuItem::Scoreboard {
-                        let _ = self.network_requests.send(NetworkRequest::Schedule { date }).await;
+                        let _ = self.network_requests.send(NetworkRequest::Schedule { date }.into()).await;
                         if game_id > 0 {
-                            let _ = self.network_requests.send(NetworkRequest::GameData { game_id }).await;
+                            let _ = self.network_requests.send(NetworkRequest::GameData { game_id }.into()).await;
                         }
                     }
                 }
@@ -56,7 +56,7 @@ impl PeriodicRefresher {
                     };
 
                     if active_tab == MenuItem::Standings {
-                        let _ = self.network_requests.send(NetworkRequest::Standings { date }).await;
+                        let _ = self.network_requests.send(NetworkRequest::Standings { date }.into()).await;
                     }
                 }
 
@@ -68,7 +68,7 @@ impl PeriodicRefresher {
                     };
 
                     if active_tab == MenuItem::Stats {
-                        let _ = self.network_requests.send(NetworkRequest::Stats { date, stat_type }).await;
+                        let _ = self.network_requests.send(NetworkRequest::Stats { date, stat_type }.into()).await;
                     }
                 }
             }

--- a/src/state/stats.rs
+++ b/src/state/stats.rs
@@ -114,9 +114,9 @@ impl StatsState {
         &mut self,
         team_id: u16,
         date: NaiveDate,
-        schedule: ScheduleResponse,
-        roster: RosterResponse,
-        transactions: TransactionsResponse,
+        schedule: &ScheduleResponse,
+        roster: &RosterResponse,
+        transactions: &TransactionsResponse,
         tz: Tz,
     ) {
         let team = lookup_team_by_id(team_id).unwrap_or_default();
@@ -133,7 +133,7 @@ impl StatsState {
     pub fn update_team_roster(
         &mut self,
         team_id: u16,
-        roster: RosterResponse,
+        roster: &RosterResponse,
         roster_type: RosterType,
     ) {
         if let Some(tp) = &mut self.team_page
@@ -143,13 +143,13 @@ impl StatsState {
         }
     }
 
-    pub fn update_team_player_profile(&mut self, data: PeopleResponse, game_type: GameType) {
+    pub fn update_team_player_profile(&mut self, data: Arc<PeopleResponse>, game_type: GameType) {
         if let Some(tp) = &mut self.team_page {
             tp.update_player_profile(data, game_type);
         }
     }
 
-    pub fn update_player_profile(&mut self, data: PeopleResponse, game_type: GameType) {
+    pub fn update_player_profile(&mut self, data: Arc<PeopleResponse>, game_type: GameType) {
         let season_year = self.date_selector.date.year();
         self.player_profile =
             PlayerProfileState::from_response(data, self.stat_type.group, game_type, season_year);

--- a/src/state/team_page.rs
+++ b/src/state/team_page.rs
@@ -9,6 +9,7 @@ use mlbt_api::schedule::ScheduleResponse;
 use mlbt_api::season::GameType;
 use mlbt_api::team::{RosterResponse, RosterType, TransactionsResponse};
 use std::collections::HashSet;
+use std::sync::Arc;
 use tui::widgets::TableState;
 
 #[derive(Debug, Clone, Copy, PartialEq)]
@@ -46,9 +47,9 @@ impl TeamPageState {
     pub fn from_response(
         team: Team,
         date: chrono::NaiveDate,
-        schedule: ScheduleResponse,
-        roster: RosterResponse,
-        transactions: TransactionsResponse,
+        schedule: &ScheduleResponse,
+        roster: &RosterResponse,
+        transactions: &TransactionsResponse,
         tz: Tz,
     ) -> Self {
         let schedule = TeamGame::from_schedule(schedule, team.id, date, tz);
@@ -91,7 +92,7 @@ impl TeamPageState {
         }
     }
 
-    pub fn update_roster(&mut self, roster: RosterResponse, roster_type: RosterType) {
+    pub fn update_roster(&mut self, roster: &RosterResponse, roster_type: RosterType) {
         self.roster = RosterRow::from_roster(roster);
         self.roster_type = roster_type;
         let (len, headers, map) = build_roster_row_map(&self.roster);
@@ -256,7 +257,7 @@ impl TeamPageState {
 
     pub fn update_player_profile(
         &mut self,
-        data: mlbt_api::player::PeopleResponse,
+        data: Arc<mlbt_api::player::PeopleResponse>,
         game_type: GameType,
     ) {
         let group = self


### PR DESCRIPTION
This adds a caching layer to API requests. It's reasonably smart in that the game state (notably a game that is `Final`) determines the cache TTL, and what gets invalidated.

Also adds debouncing, so if you scroll through the schedule quickly you don't load every game you scroll through.