### PR TITLE
Allow wrapping on help text scroll

### DIFF
--- a/src/components/help.rs
+++ b/src/components/help.rs
@@ -2,6 +2,15 @@ use crate::app::MenuItem;
 
 pub const HEADER: &[&str; 2] = &["Description", "Key"];
 
+/// Total row count of the docs table.
+pub const DOCS_LEN: usize = GENERAL_DOCS.len()
+    + SCOREBOARD_DOCS.len()
+    + GAMEDAY_DOCS.len()
+    + STATS_DOCS.len()
+    + STANDINGS_DOCS.len()
+    + TEAM_PAGE_DOCS.len()
+    + PLAYER_PROFILE_DOCS.len();
+
 const GENERAL_DOCS: &[&[&str; 2]; 9] = &[
     &["Exit help", "Esc"],
     &["Move down", "j/↓"],

--- a/src/components/schedule.rs
+++ b/src/components/schedule.rs
@@ -145,6 +145,10 @@ impl ScheduleState {
     }
 
     pub fn next(&mut self) {
+        if self.schedule.is_empty() {
+            self.state.select(None);
+            return;
+        }
         let i = match self.state.selected() {
             Some(i) => {
                 if i >= self.schedule.len() - 1 {
@@ -159,6 +163,10 @@ impl ScheduleState {
     }
 
     pub fn previous(&mut self) {
+        if self.schedule.is_empty() {
+            self.state.select(None);
+            return;
+        }
         let i = match self.state.selected() {
             Some(i) => {
                 if i == 0 {

--- a/src/state/help.rs
+++ b/src/state/help.rs
@@ -1,3 +1,4 @@
+use crate::components::help::DOCS_LEN;
 use tui::widgets::TableState;
 
 pub struct HelpState {
@@ -14,11 +15,20 @@ impl Default for HelpState {
 
 impl HelpState {
     pub fn next(&mut self) {
-        self.state.scroll_down_by(1);
+        let i = match self.state.selected() {
+            Some(i) if i >= DOCS_LEN - 1 => 0,
+            Some(i) => i + 1,
+            None => 0,
+        };
+        self.state.select(Some(i));
     }
 
     pub fn previous(&mut self) {
-        self.state.scroll_up_by(1);
+        let i = match self.state.selected() {
+            Some(0) | None => DOCS_LEN - 1,
+            Some(i) => i - 1,
+        };
+        self.state.select(Some(i));
     }
 
     pub fn page_down(&mut self) {


### PR DESCRIPTION
- all scrolling allows wrapping around from top/bottom, so the Help page should too
- also fix an edge case in schedule scrolling where there is no data and scrolling would cause a panic