### PR TITLE
Update Stats with all/qualified toggle and save sort preferences

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- Add `all | qualified` toggle to Stats and save sort + column preferences in
+  memory: [PR 137](https://github.com/mlb-rs/mlbt/pull/137)
+ 
 ## [0.3.1] - 2026-04-16
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -231,8 +231,8 @@ used for sorting the stats and toggling columns on/off.
 | `Shift` + `k` / `↑` | page up in stats table                                 |
 | `:`                 | activate date picker (see [Date Picker](#date-picker)) |
 
-You can switch between `pitching` and `hitting` stats and filter based on `team`
-or `player` using:
+Switch between `pitching` and `hitting` stats, filter by `team` or `player`, and
+choose to view `all` or just `qualified` players.
 
 | Key | Description |
 |-----|-------------|
@@ -240,6 +240,8 @@ or `player` using:
 | `h` | hitting     |
 | `t` | team        |
 | `l` | player      |
+| `a` | all players |
+| `u` | qualified   |
 
 #### Search
 

--- a/api/src/client.rs
+++ b/api/src/client.rs
@@ -83,6 +83,25 @@ impl StatGroup {
     }
 }
 
+/// Filter for the `playerPool` query parameter on player stats endpoints.
+/// `Qualified` restricts results to players meeting MLB's rate-stat eligibility thresholds:
+/// (3.1 PA or 1.0 IP per team game).
+#[derive(Clone, Copy, Debug, Default, Eq, Hash, PartialEq)]
+pub enum Qualification {
+    #[default]
+    All,
+    Qualified,
+}
+
+impl fmt::Display for Qualification {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            Qualification::All => write!(f, "all"),
+            Qualification::Qualified => write!(f, "qualified"),
+        }
+    }
+}
+
 impl MLBApi {
     pub async fn get_todays_schedule(&self) -> ApiResult<ScheduleResponse> {
         let url = format!(
@@ -190,16 +209,18 @@ impl MLBApi {
     pub async fn get_player_stats(
         &self,
         group: StatGroup,
+        qualification: Qualification,
         game_type: GameType,
     ) -> ApiResult<StatsResponse> {
         let local: DateTime<Local> = Local::now();
         let sort = group.default_sort_stat();
         let mut url = format!(
-            "{}v1/stats?sportId=1&stats=season&season={}&group={}&limit=3000&sortStat={}&order=desc&playerPool=ALL",
+            "{}v1/stats?sportId=1&stats=season&season={}&group={}&limit=3000&sortStat={}&order=desc&playerPool={}",
             self.base_url,
             local.year(),
             group,
-            sort
+            sort,
+            qualification,
         );
         if game_type == GameType::SpringTraining {
             url.push_str("&gameType=S");
@@ -210,6 +231,7 @@ impl MLBApi {
     pub async fn get_player_stats_on_date(
         &self,
         group: StatGroup,
+        qualification: Qualification,
         date: NaiveDate,
         game_type: GameType,
     ) -> ApiResult<StatsResponse> {
@@ -217,32 +239,38 @@ impl MLBApi {
         let url = match game_type {
             // Spring training doesn't work well with byDateRange, use season instead.
             GameType::SpringTraining => format!(
-                "{}v1/stats?sportId=1&stats=season&season={}&group={}&limit=3000&sortStat={}&order=desc&gameType=S&playerPool=ALL",
+                "{}v1/stats?sportId=1&stats=season&season={}&group={}&limit=3000&sortStat={}&order=desc&gameType=S&playerPool={}",
                 self.base_url,
                 date.year(),
                 group,
-                sort
+                sort,
+                qualification,
             ),
             GameType::RegularSeason => {
                 let current_year = Local::now().year();
-                if date.year() < current_year {
-                    // For past seasons use season stats because its way faster, and you can't use
-                    // a date range anyway.
+                // Past seasons use season stats because byDateRange is much slower on a cold cache.
+                // Qualified must also use season stats because the API ignores `playerPool` on
+                // byDateRange queries.
+                let use_season =
+                    date.year() < current_year || qualification == Qualification::Qualified;
+                if use_season {
                     format!(
-                        "{}v1/stats?sportId=1&stats=season&season={}&group={}&limit=3000&sortStat={}&order=desc&playerPool=ALL",
+                        "{}v1/stats?sportId=1&stats=season&season={}&group={}&limit=3000&sortStat={}&order=desc&playerPool={}",
                         self.base_url,
                         date.year(),
                         group,
-                        sort
+                        sort,
+                        qualification,
                     )
                 } else {
                     format!(
-                        "{}v1/stats?sportId=1&stats=byDateRange&season={}&endDate={}&group={}&limit=3000&sortStat={}&order=desc&playerPool=ALL",
+                        "{}v1/stats?sportId=1&stats=byDateRange&season={}&endDate={}&group={}&limit=3000&sortStat={}&order=desc&playerPool={}",
                         self.base_url,
                         date.year(),
                         date.format("%Y-%m-%d"),
                         group,
-                        sort
+                        sort,
+                        qualification,
                     )
                 }
             }

--- a/api/tests/client.rs
+++ b/api/tests/client.rs
@@ -28,6 +28,7 @@ async fn generate_mock_client() -> (MLBApi, ServerGuard) {
 mod tests {
     use super::*;
     use chrono::{DateTime, Datelike, Local};
+    use mlbt_api::client::Qualification;
 
     /// Test the schedule for the All Star Game 2021
     #[tokio::test]
@@ -211,7 +212,7 @@ mod tests {
         let local: DateTime<Local> = Local::now();
         for group in [StatGroup::Hitting, StatGroup::Pitching] {
             let url = format!(
-                "/v1/stats?sportId=1&stats=season&season={}&group={}&limit=3000&sortStat={}&order=desc&playerPool=ALL",
+                "/v1/stats?sportId=1&stats=season&season={}&group={}&limit=3000&sortStat={}&order=desc&playerPool=all",
                 local.year(),
                 group,
                 group.default_sort_stat()
@@ -225,7 +226,7 @@ mod tests {
                 .create();
 
             let resp = client
-                .get_player_stats(group, GameType::RegularSeason)
+                .get_player_stats(group, Qualification::All, GameType::RegularSeason)
                 .await
                 .unwrap();
             m.assert(); // assert mock was called
@@ -241,7 +242,7 @@ mod tests {
 
         for group in [StatGroup::Hitting, StatGroup::Pitching] {
             let url = format!(
-                "/v1/stats?sportId=1&stats=season&season={}&group={}&limit=3000&sortStat={}&order=desc&playerPool=ALL",
+                "/v1/stats?sportId=1&stats=season&season={}&group={}&limit=3000&sortStat={}&order=desc&playerPool=all",
                 date.year(),
                 group,
                 group.default_sort_stat()
@@ -255,7 +256,7 @@ mod tests {
                 .create();
 
             let resp = client
-                .get_player_stats_on_date(group, date, GameType::RegularSeason)
+                .get_player_stats_on_date(group, Qualification::All, date, GameType::RegularSeason)
                 .await
                 .unwrap();
             m.assert(); // assert mock was called
@@ -272,7 +273,7 @@ mod tests {
 
         for group in [StatGroup::Hitting, StatGroup::Pitching] {
             let url = format!(
-                "/v1/stats?sportId=1&stats=byDateRange&season={}&endDate={}&group={}&limit=3000&sortStat={}&order=desc&playerPool=ALL",
+                "/v1/stats?sportId=1&stats=byDateRange&season={}&endDate={}&group={}&limit=3000&sortStat={}&order=desc&playerPool=all",
                 date.year(),
                 date.format("%Y-%m-%d"),
                 group,
@@ -287,7 +288,7 @@ mod tests {
                 .create();
 
             let resp = client
-                .get_player_stats_on_date(group, date, GameType::RegularSeason)
+                .get_player_stats_on_date(group, Qualification::All, date, GameType::RegularSeason)
                 .await
                 .unwrap();
             m.assert(); // assert mock was called
@@ -404,7 +405,7 @@ mod tests {
 
         for group in [StatGroup::Hitting, StatGroup::Pitching] {
             let url = format!(
-                "/v1/stats?sportId=1&stats=season&season={}&group={}&limit=3000&sortStat={}&order=desc&gameType=S&playerPool=ALL",
+                "/v1/stats?sportId=1&stats=season&season={}&group={}&limit=3000&sortStat={}&order=desc&gameType=S&playerPool=all",
                 date.year(),
                 group,
                 group.default_sort_stat()
@@ -418,7 +419,7 @@ mod tests {
                 .create();
 
             let resp = client
-                .get_player_stats_on_date(group, date, GameType::SpringTraining)
+                .get_player_stats_on_date(group, Qualification::All, date, GameType::SpringTraining)
                 .await
                 .unwrap();
             m.assert();

--- a/src/components/help.rs
+++ b/src/components/help.rs
@@ -47,10 +47,11 @@ const GAMEDAY_DOCS: &[&[&str; 2]; 12] = &[
     &["Go to live at bat", "l"],
     &["Go to first at bat", "s"],
 ];
-const STATS_DOCS: &[&[&str; 2]; 16] = &[
+const STATS_DOCS: &[&[&str; 2]; 17] = &[
     &["Stats", "3"],
     &["Switch hitting/pitching", "h/p"],
     &["Switch team/player", "t/l"],
+    &["Switch all/qualified", "a/u"],
     &["Switch pane", "←/→/Tab"],
     &["Move down", "j/↓"],
     &["Move up", "k/↑"],

--- a/src/components/stats/table.rs
+++ b/src/components/stats/table.rs
@@ -32,7 +32,7 @@ impl Default for StatType {
         Self {
             group: StatGroup::Hitting,
             team_player: TeamOrPlayer::Player,
-            qualification: Qualification::Qualified,
+            qualification: Qualification::All,
         }
     }
 }

--- a/src/components/stats/table.rs
+++ b/src/components/stats/table.rs
@@ -1,6 +1,6 @@
 use crate::components::constants::lookup_team;
 use indexmap::IndexMap;
-use mlbt_api::client::StatGroup;
+use mlbt_api::client::{Qualification, StatGroup};
 use mlbt_api::stats::{HittingStat, PitchingStat, StatSplit, StatsResponse};
 use std::cmp::Ordering;
 use std::string::ToString;
@@ -24,6 +24,7 @@ pub type TableData = (Vec<String>, Vec<u64>, Vec<Vec<String>>);
 pub struct StatType {
     pub group: StatGroup,
     pub team_player: TeamOrPlayer,
+    pub qualification: Qualification,
 }
 
 impl Default for StatType {
@@ -31,6 +32,7 @@ impl Default for StatType {
         Self {
             group: StatGroup::Hitting,
             team_player: TeamOrPlayer::Player,
+            qualification: Qualification::Qualified,
         }
     }
 }

--- a/src/components/stats/table.rs
+++ b/src/components/stats/table.rs
@@ -12,6 +12,8 @@ pub const STATS_FIRST_COL_WIDTH: u16 = 28;
 pub const STATS_DEFAULT_COL_WIDTH: u16 = 6;
 pub const PLAYER_COLUMN_NAME: &str = "Player";
 pub const TEAM_COLUMN_NAME: &str = "Team";
+const DEFAULT_SORT_COLUMN_PITCHING: &str = "IP";
+const DEFAULT_SORT_COLUMN_HITTING: &str = "AB";
 
 /// Table data in row oriented form: (header, ids, rows).
 /// `ids` are the player/team id for each row.
@@ -22,6 +24,15 @@ pub type TableData = (Vec<String>, Vec<u64>, Vec<Vec<String>>);
 pub struct StatType {
     pub group: StatGroup,
     pub team_player: TeamOrPlayer,
+}
+
+impl Default for StatType {
+    fn default() -> Self {
+        Self {
+            group: StatGroup::Hitting,
+            team_player: TeamOrPlayer::Player,
+        }
+    }
 }
 
 impl StatType {
@@ -38,15 +49,15 @@ impl StatType {
 
 #[derive(Clone, Copy, Debug, Default, Eq, Hash, PartialEq)]
 pub enum TeamOrPlayer {
-    #[default]
     Team,
+    #[default]
     Player,
 }
 
 #[derive(Copy, Clone, Debug, Default, Eq, PartialEq)]
 pub enum Order {
-    #[default]
     Ascending,
+    #[default]
     Descending,
 }
 
@@ -78,11 +89,15 @@ pub struct Sort {
     pub order: Order,
 }
 
-impl Default for Sort {
-    fn default() -> Self {
+impl Sort {
+    fn new(stat_type: StatType) -> Self {
+        let column_name = match stat_type.group {
+            StatGroup::Hitting => DEFAULT_SORT_COLUMN_HITTING.to_string(),
+            StatGroup::Pitching => DEFAULT_SORT_COLUMN_PITCHING.to_string(),
+        };
         Sort {
-            column_name: None,
-            order: Order::Ascending,
+            column_name: Some(column_name),
+            order: Order::Descending,
         }
     }
 }
@@ -111,18 +126,16 @@ pub struct StatsTable {
     row_ids: Vec<u64>,
 }
 
-impl Default for StatsTable {
-    fn default() -> Self {
+impl StatsTable {
+    pub fn new(stat_type: StatType) -> Self {
         Self {
             columns: IndexMap::new(),
-            sorting: Sort::default(),
+            sorting: Sort::new(stat_type),
             cache: None,
             row_ids: Vec::new(),
         }
     }
-}
 
-impl StatsTable {
     pub fn invalidate_cache(&mut self) {
         self.cache = None;
     }
@@ -131,9 +144,10 @@ impl StatsTable {
         self.cache.as_ref()
     }
 
-    pub fn load(&mut self, stats: &StatsResponse, team_player: TeamOrPlayer) {
+    pub fn load(&mut self, stats: &StatsResponse, stat_type: StatType) {
         self.columns.clear();
         self.row_ids.clear();
+        self.sorting = Sort::new(stat_type);
         self.invalidate_cache();
         for stat in &stats.stats {
             for split in &stat.splits {
@@ -151,10 +165,10 @@ impl StatsTable {
                 self.row_ids.push(id);
                 match &split.stat {
                     StatSplit::Pitching(s) => {
-                        self.load_pitching_stats(name, team_abbreviation, s, team_player)
+                        self.load_pitching_stats(name, team_abbreviation, s, stat_type.team_player)
                     }
                     StatSplit::Hitting(s) => {
-                        self.load_hitting_stats(name, team_abbreviation, s, team_player)
+                        self.load_hitting_stats(name, team_abbreviation, s, stat_type.team_player)
                     }
                 };
             }

--- a/src/components/util.rs
+++ b/src/components/util.rs
@@ -3,7 +3,9 @@ use chrono_tz::Tz;
 use log::error;
 use tui::style::Color;
 
-/// Returns `Color::DarkGray` when the value is zero, otherwise the given fallback color.
+pub const DIM_COLOR: Color = Color::DarkGray;
+
+/// Returns `DIM_COLOR` when the value is zero, otherwise the given fallback color.
 /// e.g. `self.hits.dim_or(color)`
 pub(crate) trait DimColor {
     fn dim_or(&self, fallback: Color) -> Color;
@@ -13,7 +15,7 @@ macro_rules! impl_dim_color_int {
     ($($t:ty),*) => {
         $(impl DimColor for $t {
             fn dim_or(&self, fallback: Color) -> Color {
-                if *self == 0 { Color::DarkGray } else { fallback }
+                if *self == 0 { DIM_COLOR } else { fallback }
             }
         })*
     };

--- a/src/keys.rs
+++ b/src/keys.rs
@@ -6,7 +6,7 @@ use crate::state::settings_editor::SettingsFocus;
 use crate::state::stats::ActivePane;
 use crossterm::event::KeyCode::Char;
 use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
-use mlbt_api::client::StatGroup;
+use mlbt_api::client::{Qualification, StatGroup};
 use std::sync::Arc;
 use tokio::sync::{Mutex, MutexGuard, mpsc};
 
@@ -165,6 +165,18 @@ pub async fn handle_key_bindings(
         }
         (MenuItem::Stats, Char('t'), _) => {
             guard.state.stats.stat_type.team_player = TeamOrPlayer::Team;
+            load_stats(guard, network_requests, false).await;
+        }
+        (MenuItem::Stats, Char('a'), _)
+            if guard.state.stats.stat_type.team_player == TeamOrPlayer::Player =>
+        {
+            guard.state.stats.stat_type.qualification = Qualification::All;
+            load_stats(guard, network_requests, false).await;
+        }
+        (MenuItem::Stats, Char('u'), _)
+            if guard.state.stats.stat_type.team_player == TeamOrPlayer::Player =>
+        {
+            guard.state.stats.stat_type.qualification = Qualification::Qualified;
             load_stats(guard, network_requests, false).await;
         }
         (MenuItem::Stats, KeyCode::Enter, _) => {

--- a/src/state/cache.rs
+++ b/src/state/cache.rs
@@ -413,10 +413,7 @@ mod tests {
         cache.insert(
             CacheKey::Stats {
                 date,
-                stat_type: StatType {
-                    group: StatGroup::Hitting,
-                    team_player: crate::components::stats::table::TeamOrPlayer::Player,
-                },
+                stat_type: StatType::default(),
             },
             NetworkResponse::StatsLoaded {
                 stats: Arc::new(mlbt_api::stats::StatsResponse::default()),
@@ -436,10 +433,7 @@ mod tests {
             cache
                 .get(&CacheKey::Stats {
                     date,
-                    stat_type: StatType {
-                        group: StatGroup::Hitting,
-                        team_player: crate::components::stats::table::TeamOrPlayer::Player,
-                    },
+                    stat_type: StatType::default(),
                 })
                 .is_none()
         );

--- a/src/state/network.rs
+++ b/src/state/network.rs
@@ -256,7 +256,11 @@ impl NetworkWorker {
         debug!("loading {stat_type:?} stats for {date}");
         self.ensure_season_info(date).await;
         let game_type = game_type_for_date(date, self.cached_season_info());
-        let StatType { team_player, group } = stat_type;
+        let StatType {
+            team_player,
+            group,
+            qualification,
+        } = stat_type;
         let stats = match team_player {
             TeamOrPlayer::Team => {
                 self.client
@@ -265,7 +269,7 @@ impl NetworkWorker {
             }
             TeamOrPlayer::Player => {
                 self.client
-                    .get_player_stats_on_date(group, date, game_type)
+                    .get_player_stats_on_date(group, qualification, date, game_type)
                     .await
             }
         }?;

--- a/src/state/stats.rs
+++ b/src/state/stats.rs
@@ -241,13 +241,6 @@ impl StatsState {
         self.select(Some(0));
     }
 
-    fn select(&mut self, index: Option<usize>) {
-        match self.active_pane {
-            ActivePane::Data => self.data_state.select(index),
-            ActivePane::Options => self.options_state.select(index),
-        }
-    }
-
     /// Set the date using Left/Right arrow keys to move a single day at a time.
     pub fn set_date_with_arrows(&mut self, forward: bool) -> NaiveDate {
         self.date_selector.set_date_with_arrows(forward)
@@ -388,82 +381,178 @@ impl StatsState {
     }
 
     pub fn next(&mut self) {
-        let len = match self.active_pane {
-            ActivePane::Data => self.row_count(),
-            ActivePane::Options => self.table.columns.len(),
-        };
+        let len = self.active_pane_len();
         if len == 0 {
             return;
         }
-        let selected = match self.active_pane {
-            ActivePane::Data => self.data_state.selected(),
-            ActivePane::Options => self.options_state.selected(),
-        };
-        let i = match selected {
-            Some(i) => {
-                if i >= len - 1 {
-                    0
-                } else {
-                    i + 1
-                }
-            }
+
+        let next = match self.selected() {
+            Some(i) if i >= len - 1 => 0,
+            Some(i) => i + 1,
             None => 0,
         };
-        self.select(Some(i));
+
+        self.select(Some(next));
+    }
+
+    pub fn previous(&mut self) {
+        let len = self.active_pane_len();
+        if len == 0 {
+            return;
+        }
+
+        let previous = match self.selected() {
+            Some(0) => len - 1,
+            Some(i) => i - 1,
+            None => 0,
+        };
+
+        self.select(Some(previous));
+    }
+
+    fn select(&mut self, index: Option<usize>) {
+        match self.active_pane {
+            ActivePane::Data => self.data_state.select(index),
+            ActivePane::Options => self.options_state.select(index),
+        }
+    }
+
+    fn selected(&self) -> Option<usize> {
+        match self.active_pane {
+            ActivePane::Data => self.data_state.selected(),
+            ActivePane::Options => self.options_state.selected(),
+        }
+    }
+
+    fn active_pane_len(&self) -> usize {
+        match self.active_pane {
+            ActivePane::Data => self.row_count(),
+            ActivePane::Options => self.table.columns.len(),
+        }
     }
 
     pub fn page_down(&mut self) {
-        if self.active_pane != ActivePane::Data {
-            return;
-        }
-        let len = self.row_count();
-        if len == 0 || self.visible_rows == 0 {
+        if !self.can_page_data() {
             return;
         }
         // The last visible row becomes the first visible row
+        let len = self.row_count();
         let offset = self.data_state.offset();
         let last_visible = (offset + self.visible_rows - 1).min(len - 1);
-        *self.data_state.offset_mut() = last_visible;
-        self.data_state.select(Some(last_visible));
+        self.select_data_row(last_visible);
     }
 
     pub fn page_up(&mut self) {
-        if self.active_pane != ActivePane::Data {
-            return;
-        }
-        let len = self.row_count();
-        if len == 0 || self.visible_rows == 0 {
+        if !self.can_page_data() {
             return;
         }
         // The first visible row becomes the last visible row
         let offset = self.data_state.offset();
         let new_offset = offset.saturating_sub(self.visible_rows - 1);
-        *self.data_state.offset_mut() = new_offset;
-        self.data_state.select(Some(new_offset));
+        self.select_data_row(new_offset);
     }
 
-    pub fn previous(&mut self) {
-        let len = match self.active_pane {
-            ActivePane::Data => self.row_count(),
-            ActivePane::Options => self.table.columns.len(),
-        };
-        if len == 0 {
-            return;
+    fn can_page_data(&self) -> bool {
+        self.active_pane == ActivePane::Data && self.row_count() > 0 && self.visible_rows > 0
+    }
+
+    fn select_data_row(&mut self, index: usize) {
+        *self.data_state.offset_mut() = index;
+        self.data_state.select(Some(index));
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::components::stats::table::TableEntry;
+
+    fn state_with(n_rows: usize, n_cols: usize) -> StatsState {
+        let mut s = StatsState::default();
+        for i in 0..n_cols {
+            s.table.columns.insert(
+                format!("c{i}"),
+                TableEntry {
+                    description: String::new(),
+                    active: true,
+                    rows: (0..n_rows).map(|r| r.to_string()).collect(),
+                },
+            );
         }
-        let selected = match self.active_pane {
-            ActivePane::Data => self.data_state.selected(),
-            ActivePane::Options => self.options_state.selected(),
-        };
-        let i = match selected {
-            Some(i) => {
-                if i == 0 {
-                    len - 1
-                } else {
-                    i - 1
-                }
-            }
-            None => 0,
-        };
-        self.select(Some(i));
+        s
+    }
+
+    #[test]
+    fn next_wraps_at_end() {
+        let mut s = state_with(3, 1);
+        s.data_state.select(Some(2));
+        s.next();
+        assert_eq!(s.data_state.selected(), Some(0));
+    }
+
+    #[test]
+    fn previous_wraps_at_start() {
+        let mut s = state_with(3, 1);
+        s.data_state.select(Some(0));
+        s.previous();
+        assert_eq!(s.data_state.selected(), Some(2));
+    }
+
+    #[test]
+    fn next_targets_active_pane() {
+        let mut s = state_with(5, 3);
+        s.active_pane = ActivePane::Options;
+        s.options_state.select(Some(0));
+        s.next();
+        assert_eq!(s.options_state.selected(), Some(1));
+        assert_eq!(s.data_state.selected(), Some(0));
+    }
+
+    #[test]
+    fn page_down_jumps_to_last_visible() {
+        let mut s = state_with(20, 1);
+        s.visible_rows = 5;
+        s.data_state.select(Some(0));
+        s.page_down();
+        assert_eq!(s.data_state.selected(), Some(4));
+    }
+
+    #[test]
+    fn page_up_reverses_page_down() {
+        let mut s = state_with(20, 1);
+        s.visible_rows = 5;
+        *s.data_state.offset_mut() = 10;
+        s.data_state.select(Some(10));
+        s.page_up();
+        assert_eq!(s.data_state.selected(), Some(6));
+    }
+
+    #[test]
+    fn page_down_clamps_at_end() {
+        let mut s = state_with(20, 1);
+        s.visible_rows = 5;
+        *s.data_state.offset_mut() = 19;
+        s.data_state.select(Some(19));
+        s.page_down();
+        assert_eq!(s.data_state.selected(), Some(19));
+    }
+
+    #[test]
+    fn page_up_clamps_at_start() {
+        let mut s = state_with(20, 1);
+        s.visible_rows = 5;
+        s.data_state.select(Some(0));
+        s.page_up();
+        assert_eq!(s.data_state.selected(), Some(0));
+    }
+
+    #[test]
+    fn page_noop_on_options_pane() {
+        let mut s = state_with(20, 1);
+        s.visible_rows = 5;
+        s.active_pane = ActivePane::Options;
+        s.data_state.select(Some(0));
+        s.page_down();
+        assert_eq!(s.data_state.selected(), Some(0));
     }
 }

--- a/src/state/stats.rs
+++ b/src/state/stats.rs
@@ -2,18 +2,20 @@ use crate::components::constants::lookup_team_by_id;
 use crate::components::date_selector::DateSelector;
 use crate::components::stats::search::SearchState;
 use crate::components::stats::table::{
-    PLAYER_COLUMN_NAME, StatType, StatsTable, TEAM_COLUMN_NAME, TableData, TeamOrPlayer,
+    PLAYER_COLUMN_NAME, Sort, StatType, StatsTable, TEAM_COLUMN_NAME, TableData, TeamOrPlayer,
 };
 use crate::state::messages::NetworkRequest;
 use crate::state::player_profile::PlayerProfileState;
 use crate::state::team_page::TeamPageState;
 use chrono::{Datelike, NaiveDate};
 use chrono_tz::Tz;
+use mlbt_api::client::StatGroup;
 use mlbt_api::player::PeopleResponse;
 use mlbt_api::schedule::ScheduleResponse;
 use mlbt_api::season::GameType;
 use mlbt_api::stats::StatsResponse;
 use mlbt_api::team::{RosterResponse, RosterType, TransactionsResponse};
+use std::collections::HashMap;
 use std::sync::Arc;
 use tui::widgets::TableState;
 
@@ -22,6 +24,22 @@ pub enum ActivePane {
     #[default]
     Data,
     Options,
+}
+
+/// Identifies a stat table view. Qualification is excluded since it only filters rows.
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+struct ViewKey {
+    group: StatGroup,
+    team_player: TeamOrPlayer,
+}
+
+/// Sort and column visibility for one `ViewKey`.
+#[derive(Clone, Default)]
+struct ViewPrefs {
+    /// Sort column + order. `None` falls back to the default in `Sort::new`.
+    sort: Option<Sort>,
+    /// Column name to active flag, only for columns that have been toggled.
+    column_overrides: HashMap<String, bool>,
 }
 
 /// Stores the state for rendering the stats.
@@ -34,7 +52,7 @@ pub struct StatsState {
     pub active_pane: ActivePane,
     /// Pane that was active before search opened, used to restore on cancel.
     pub search_previous_pane: Option<ActivePane>,
-    /// The stat type combination of team/player and pitching/hitting.
+    /// The stat type combination of team/player, pitching/hitting, and all/qualified.
     pub stat_type: StatType,
     /// The stats table data and cache.
     pub table: StatsTable,
@@ -50,6 +68,11 @@ pub struct StatsState {
     pub player_profile: Option<PlayerProfileState>,
     /// Active team page view. When Some, renders full-page replacing the stats table.
     pub team_page: Option<TeamPageState>,
+    /// Sort and column visibility per `ViewKey`, restored on `update()`.
+    view_prefs: HashMap<ViewKey, ViewPrefs>,
+    /// Last `ViewKey` seen by `update()`. Used to keep the options pane row when only qualification
+    /// toggles, since the stats columns don't change.
+    last_view_key: Option<ViewKey>,
 }
 
 impl Default for StatsState {
@@ -68,6 +91,8 @@ impl Default for StatsState {
             search: SearchState::default(),
             player_profile: None,
             team_page: None,
+            view_prefs: HashMap::new(),
+            last_view_key: None,
         };
         ss.options_state.select(Some(0));
         ss.data_state.select(Some(0));
@@ -77,13 +102,53 @@ impl Default for StatsState {
 
 impl StatsState {
     pub fn update(&mut self, stats: &StatsResponse) {
+        let current_key = self.view_key();
+        let same_view = self.last_view_key == Some(current_key);
+        self.last_view_key = Some(current_key);
+
         self.player_profile = None;
         self.table.load(stats, self.stat_type);
+        self.apply_view_prefs();
         self.data_state.select(Some(0));
-        self.options_state.select(Some(0));
+        // Only reset the options pane row selection if the columns could differ.
+        if !same_view {
+            self.options_state.select(Some(0));
+        }
         // Clear search state since the underlying data has changed.
         self.search.close();
         self.search_previous_pane = None;
+    }
+
+    fn view_key(&self) -> ViewKey {
+        ViewKey {
+            group: self.stat_type.group,
+            team_player: self.stat_type.team_player,
+        }
+    }
+
+    /// Restore saved sort and column visibility for the current view. Called after `table.load()`
+    /// has reset everything to defaults.
+    fn apply_view_prefs(&mut self) {
+        let Some(prefs) = self.view_prefs.get(&self.view_key()) else {
+            return;
+        };
+        for (name, active) in &prefs.column_overrides {
+            if let Some(entry) = self.table.columns.get_mut(name) {
+                entry.active = *active;
+            }
+        }
+
+        // Only restore the saved sort if its column still exists and is visible.
+        if let Some(sort) = &prefs.sort
+            && let Some(name) = &sort.column_name
+            && self
+                .table
+                .columns
+                .get(name)
+                .is_some_and(|entry| entry.active)
+        {
+            self.table.sorting = sort.clone();
+        }
     }
 
     pub fn has_player_profile(&self) -> bool {
@@ -266,6 +331,16 @@ impl StatsState {
     pub fn toggle_stat(&mut self) {
         let idx = self.options_state.selected().unwrap_or_default();
         self.table.toggle_stat(idx);
+        let key = self.view_key();
+        let prefs = self.view_prefs.entry(key).or_default();
+        if let Some((name, entry)) = self.table.columns.get_index(idx) {
+            prefs.column_overrides.insert(name.clone(), entry.active);
+        }
+        // StatsTable.toggle_stat clears the sort if the sort column was toggled off. Mirror that so
+        // it doesn't come back on the next view switch.
+        if self.table.sorting.column_name.is_none() {
+            prefs.sort = None;
+        }
     }
 
     /// Sort the table by the selected stat.
@@ -274,6 +349,13 @@ impl StatsState {
             return;
         };
         self.table.store_sort_column(idx);
+        let key = self.view_key();
+        let prefs = self.view_prefs.entry(key).or_default();
+        prefs.sort = if self.table.sorting.column_name.is_some() {
+            Some(self.table.sorting.clone())
+        } else {
+            None
+        };
     }
 
     /// Get the player or team id for the currently selected row.

--- a/src/state/stats.rs
+++ b/src/state/stats.rs
@@ -9,7 +9,6 @@ use crate::state::player_profile::PlayerProfileState;
 use crate::state::team_page::TeamPageState;
 use chrono::{Datelike, NaiveDate};
 use chrono_tz::Tz;
-use mlbt_api::client::StatGroup;
 use mlbt_api::player::PeopleResponse;
 use mlbt_api::schedule::ScheduleResponse;
 use mlbt_api::season::GameType;
@@ -55,16 +54,14 @@ pub struct StatsState {
 
 impl Default for StatsState {
     fn default() -> Self {
+        let stat_type = StatType::default();
         let mut ss = StatsState {
             options_state: TableState::default(),
             data_state: TableState::default(),
             active_pane: ActivePane::default(),
             search_previous_pane: None,
-            stat_type: StatType {
-                group: StatGroup::Hitting,
-                team_player: TeamOrPlayer::Player,
-            },
-            table: StatsTable::default(),
+            stat_type,
+            table: StatsTable::new(stat_type),
             show_options: true,
             date_selector: DateSelector::default(),
             visible_rows: 0,
@@ -81,7 +78,7 @@ impl Default for StatsState {
 impl StatsState {
     pub fn update(&mut self, stats: &StatsResponse) {
         self.player_profile = None;
-        self.table.load(stats, self.stat_type.team_player);
+        self.table.load(stats, self.stat_type);
         self.data_state.select(Some(0));
         self.options_state.select(Some(0));
         // Clear search state since the underlying data has changed.

--- a/src/ui/stats.rs
+++ b/src/ui/stats.rs
@@ -61,9 +61,9 @@ impl StatefulWidget for StatsDataWidget {
                     .enumerate()
                     .map(|(i, cell)| {
                         let color = if Some(i) == avg_idx {
-                            avg_color(cell).unwrap_or(Color::default())
+                            avg_color(cell).unwrap_or_default()
                         } else if Some(i) == era_idx {
-                            era_color(cell).unwrap_or(Color::default())
+                            era_color(cell).unwrap_or_default()
                         } else {
                             cell.as_str().dim_or(Color::default())
                         };

--- a/src/ui/stats.rs
+++ b/src/ui/stats.rs
@@ -1,13 +1,14 @@
 use crate::components::stats::table::TeamOrPlayer;
 use crate::components::stats::{STATS_DEFAULT_COL_WIDTH, STATS_FIRST_COL_WIDTH};
-use crate::components::util::{DimColor, avg_color, era_color};
+use crate::components::util::{DIM_COLOR, DimColor, avg_color, era_color};
 use crate::state::stats::{ActivePane, StatsState};
-use mlbt_api::client::StatGroup;
+use mlbt_api::client::{Qualification, StatGroup};
 use tui::prelude::*;
-use tui::widgets::{Block, BorderType, Borders, Cell, Padding, Paragraph, Row, Table, Wrap};
+use tui::widgets::{Block, BorderType, Borders, Cell, Padding, Paragraph, Row, Table};
 
 pub const STATS_OPTIONS_WIDTH: u16 = 36;
-const HIGHLIGHT_STYLE: Style = Style::new().bg(Color::Blue).fg(Color::Black);
+const HIGHLIGHT_COLOR: Color = Color::Blue;
+const HIGHLIGHT_STYLE: Style = Style::new().bg(HIGHLIGHT_COLOR).fg(Color::Black);
 
 /// Renders the stats data table (left pane).
 pub struct StatsDataWidget {}
@@ -44,7 +45,7 @@ impl StatefulWidget for StatsDataWidget {
                         "{name} {}",
                         state.table.sorting.order.arrow_symbol()
                     ))
-                    .style(Style::default().bg(Color::Blue))
+                    .bg(HIGHLIGHT_COLOR)
                 } else {
                     Cell::from(name.as_str())
                 }
@@ -60,11 +61,11 @@ impl StatefulWidget for StatsDataWidget {
                     .enumerate()
                     .map(|(i, cell)| {
                         let color = if Some(i) == avg_idx {
-                            avg_color(cell).unwrap_or(Color::White)
+                            avg_color(cell).unwrap_or(Color::default())
                         } else if Some(i) == era_idx {
-                            era_color(cell).unwrap_or(Color::White)
+                            era_color(cell).unwrap_or(Color::default())
                         } else {
-                            cell.as_str().dim_or(Color::White)
+                            cell.as_str().dim_or(Color::default())
                         };
                         Cell::from(cell.as_str()).fg(color)
                     })
@@ -93,7 +94,7 @@ impl StatefulWidget for StatsDataWidget {
                     .padding(Padding::new(1, 1, 0, 0))
                     .title(Span::styled(
                         state.date_selector.format_date_border_title(),
-                        Style::default().fg(Color::Black).bg(Color::Blue),
+                        HIGHLIGHT_STYLE,
                     )),
             );
         if state.active_pane == ActivePane::Data {
@@ -115,10 +116,11 @@ impl StatefulWidget for StatsOptionsWidget {
 
     fn render(self, area: Rect, buf: &mut Buffer, state: &mut Self::State) {
         let [stats_rect, options_rect] =
-            Layout::vertical([Constraint::Length(4), Constraint::Percentage(100)]).areas(area);
+            Layout::vertical([Constraint::Length(5), Constraint::Percentage(100)]).areas(area);
 
         // hitting | pitching
-        // team | player
+        //    team | player
+        //     all | qualified
         let (hitting_style, pitching_style) = match state.stat_type.group {
             StatGroup::Pitching => (Style::default(), HIGHLIGHT_STYLE),
             StatGroup::Hitting => (HIGHLIGHT_STYLE, Style::default()),
@@ -127,27 +129,60 @@ impl StatefulWidget for StatsOptionsWidget {
             TeamOrPlayer::Player => (Style::default(), HIGHLIGHT_STYLE),
             TeamOrPlayer::Team => (HIGHLIGHT_STYLE, Style::default()),
         };
-        let text = vec![
-            Line::from(vec![
-                Span::styled("hitting", hitting_style),
-                Span::raw(" | "),
-                Span::styled("pitching", pitching_style),
-            ]),
-            Line::from(vec![
-                Span::styled("team", team_style),
-                Span::raw(" | "),
-                Span::styled("player", player_style),
-            ]),
-        ];
-        Paragraph::new(text)
-            .block(
-                Block::default()
-                    .borders(Borders::ALL)
-                    .border_type(BorderType::Rounded),
-            )
-            .alignment(Alignment::Center)
-            .wrap(Wrap { trim: true })
-            .render(stats_rect, buf);
+
+        let is_team = state.stat_type.team_player == TeamOrPlayer::Team;
+        let dim_if_team = if is_team {
+            Style::default().fg(DIM_COLOR)
+        } else {
+            Style::default()
+        };
+        let (all_style, qualified_style) = if is_team {
+            // disable qualification selection when Team is selected because it's not applicable
+            (dim_if_team, dim_if_team)
+        } else {
+            match state.stat_type.qualification {
+                Qualification::All => (HIGHLIGHT_STYLE, Style::default()),
+                Qualification::Qualified => (Style::default(), HIGHLIGHT_STYLE),
+            }
+        };
+
+        let block = Block::default()
+            .borders(Borders::ALL)
+            .border_type(BorderType::Rounded);
+        let inner = block.inner(stats_rect);
+        block.render(stats_rect, buf);
+
+        // split into three chunks so that the center line is always exactly in the center
+        let [left_area, divider_area, right_area] = Layout::horizontal([
+            Constraint::Fill(1),
+            Constraint::Length(3),
+            Constraint::Fill(1),
+        ])
+        .areas(inner);
+
+        Paragraph::new(vec![
+            Line::from(Span::styled("hitting", hitting_style)),
+            Line::from(Span::styled("team", team_style)),
+            Line::from(Span::styled("all", all_style)),
+        ])
+        .alignment(Alignment::Right)
+        .render(left_area, buf);
+
+        Paragraph::new(vec![
+            Line::from(" | "),
+            Line::from(" | "),
+            Line::from(" | ").style(dim_if_team),
+        ])
+        .alignment(Alignment::Center)
+        .render(divider_area, buf);
+
+        Paragraph::new(vec![
+            Line::from(Span::styled("pitching", pitching_style)),
+            Line::from(Span::styled("player", player_style)),
+            Line::from(Span::styled("qualified", qualified_style)),
+        ])
+        .alignment(Alignment::Left)
+        .render(right_area, buf);
 
         // Create the options rows, e.g. ["[X]", "ERA", "earned run average"]
         let mut options = Vec::new();


### PR DESCRIPTION
This adds an "all | qualified" toggle to the Stats page. When searching was added, the API was also changed to return "all" players instead of the default "qualified". This makes it annoying for sorting because of the non-qualified players juicing the numbers. 

<img width="2348" height="728" alt="stats-qualified" src="https://github.com/user-attachments/assets/455023a6-1765-48d4-8212-94f0efd35b7e" />


This also adds "preferences" to the stats sorting and column toggles so these are remembered until you close the TUI. This basically makes it so you can sort the stat page, leave to another page, and when you come back it's still sorted how it was.

Finally, refactored the stats scrolling code to clean it up and add some tests.