### PR TITLE
Use `chrono` types for improved datetime handling

### DIFF
--- a/api/src/lib.rs
+++ b/api/src/lib.rs
@@ -5,6 +5,7 @@ pub mod player;
 pub mod plays;
 pub mod schedule;
 pub mod season;
+pub mod serde_dates;
 pub mod standings;
 pub mod stats;
 pub mod team;

--- a/api/src/live.rs
+++ b/api/src/live.rs
@@ -1,6 +1,7 @@
 use crate::boxscore::Boxscore;
 use crate::plays::Plays;
 use crate::schedule::Status;
+use chrono::NaiveDate;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
@@ -175,7 +176,8 @@ pub struct FullPlayer {
     pub first_name: String,
     pub last_name: String,
     pub primary_number: Option<String>,
-    pub birth_date: Option<String>,
+    #[serde(default, with = "crate::serde_dates::optional_date")]
+    pub birth_date: Option<NaiveDate>,
     pub current_age: Option<i64>,
     pub birth_city: Option<String>,
     pub birth_state_province: Option<String>,
@@ -192,7 +194,8 @@ pub struct FullPlayer {
     pub is_player: Option<bool>,
     pub is_verified: Option<bool>,
     pub draft_year: Option<i64>,
-    pub mlb_debut_date: Option<String>,
+    #[serde(default, with = "crate::serde_dates::optional_date")]
+    pub mlb_debut_date: Option<NaiveDate>,
     pub bat_side: Option<Side>,
     pub pitch_hand: Option<Side>,
     pub name_first_last: Option<String>,

--- a/api/src/player.rs
+++ b/api/src/player.rs
@@ -1,6 +1,7 @@
 use crate::live::{PrimaryPosition, Side};
 use crate::schedule::IdNameLink;
 use crate::stats::Stat;
+use chrono::NaiveDate;
 use serde::Deserialize;
 
 #[derive(Default, Debug, Deserialize)]
@@ -15,7 +16,8 @@ pub struct PersonFull {
     pub id: u64,
     pub full_name: String,
     pub primary_number: Option<String>,
-    pub birth_date: Option<String>,
+    #[serde(default, with = "crate::serde_dates::optional_date")]
+    pub birth_date: Option<NaiveDate>,
     pub current_age: Option<u8>,
     pub birth_city: Option<String>,
     pub birth_state_province: Option<String>,
@@ -25,7 +27,8 @@ pub struct PersonFull {
     pub primary_position: Option<PrimaryPosition>,
     pub bat_side: Option<Side>,
     pub pitch_hand: Option<Side>,
-    pub mlb_debut_date: Option<String>,
+    #[serde(default, with = "crate::serde_dates::optional_date")]
+    pub mlb_debut_date: Option<NaiveDate>,
     pub active: Option<bool>,
     pub draft_year: Option<u16>,
     pub current_team: Option<IdNameLink>,

--- a/api/src/schedule.rs
+++ b/api/src/schedule.rs
@@ -1,4 +1,5 @@
 use crate::stats::DisplayName;
+use chrono::{DateTime, NaiveDate, Utc};
 use serde::{Deserialize, Serialize};
 
 #[derive(Default, Debug, Serialize, Deserialize)]
@@ -32,7 +33,8 @@ pub struct IdNameLink {
 #[derive(Default, Debug, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct Dates {
-    pub date: Option<String>,
+    #[serde(default, with = "crate::serde_dates::optional_date")]
+    pub date: Option<NaiveDate>,
     pub total_items: Option<u8>,
     pub total_events: Option<u8>,
     pub total_games: Option<u8>,
@@ -58,8 +60,8 @@ pub struct Game {
     pub link: String,
     // pub game_type: Option<GameType>,
     pub season: String,
-    pub game_date: String,
-    pub official_date: String,
+    pub game_date: DateTime<Utc>,
+    pub official_date: NaiveDate,
     pub status: Status,
     pub teams: Teams,
     /// Only present if `hydrate=linescore` is used.

--- a/api/src/serde_dates.rs
+++ b/api/src/serde_dates.rs
@@ -1,0 +1,65 @@
+use chrono::NaiveDate;
+use serde::{Deserialize, Deserializer, Serializer};
+
+/// Tolerant serde adapter for `Option<NaiveDate>` from API `YYYY-MM-DD` strings. Deserialization
+/// returns `None` for null, missing, or unparseable values so a single bad date doesn't fail the
+/// whole response.
+pub mod optional_date {
+    use super::*;
+
+    pub fn deserialize<'de, D>(deserializer: D) -> Result<Option<NaiveDate>, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let s = Option::<String>::deserialize(deserializer)?;
+        Ok(s.as_deref()
+            .and_then(|s| NaiveDate::parse_from_str(s, "%Y-%m-%d").ok()))
+    }
+
+    pub fn serialize<S>(date: &Option<NaiveDate>, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        match date {
+            Some(d) => serializer.serialize_str(&d.format("%Y-%m-%d").to_string()),
+            None => serializer.serialize_none(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use chrono::NaiveDate;
+    use serde::{Deserialize, Serialize};
+
+    #[derive(Serialize, Deserialize, Debug, PartialEq)]
+    struct Holder {
+        #[serde(default, with = "super::optional_date")]
+        date: Option<NaiveDate>,
+    }
+
+    #[test]
+    fn optional_date_handles_all_cases() {
+        let valid = NaiveDate::from_ymd_opt(2026, 4, 13).unwrap();
+
+        // Valid string
+        let h: Holder = serde_json::from_str(r#"{"date":"2026-04-13"}"#).unwrap();
+        assert_eq!(h.date, Some(valid));
+
+        // Null, missing, and unparseable all yield None instead of failing
+        for input in [
+            r#"{"date":null}"#,
+            r#"{}"#,
+            r#"{"date":"not-a-date"}"#,
+            r#"{"date":""}"#,
+        ] {
+            let h: Holder = serde_json::from_str(input).unwrap();
+            assert_eq!(h.date, None, "input: {input}");
+        }
+
+        // Round-trip serializes back to the same string
+        let h = Holder { date: Some(valid) };
+        let json = serde_json::to_string(&h).unwrap();
+        assert_eq!(json, r#"{"date":"2026-04-13"}"#);
+    }
+}

--- a/api/src/standings.rs
+++ b/api/src/standings.rs
@@ -1,4 +1,5 @@
 use crate::schedule::IdNameLink;
+use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 
 #[derive(Default, Debug, Serialize, Deserialize)]
@@ -13,7 +14,7 @@ pub struct Record {
     pub standings_type: String,
     pub league: IdLink,
     pub division: Option<IdLink>,
-    pub last_updated: String,
+    pub last_updated: DateTime<Utc>,
     pub team_records: Vec<TeamRecord>,
 }
 
@@ -40,7 +41,7 @@ pub struct TeamRecord {
     pub division_games_back: String,
     pub conference_games_back: String,
     pub league_record: RecordElement,
-    pub last_updated: String,
+    pub last_updated: DateTime<Utc>,
     pub records: Records,
     pub runs_allowed: u16,
     pub runs_scored: u16,

--- a/api/src/stats.rs
+++ b/api/src/stats.rs
@@ -1,4 +1,5 @@
 use crate::schedule::IdNameLink;
+use chrono::NaiveDate;
 use serde::{Deserialize, Serialize};
 
 #[derive(Default, Debug, Serialize, Deserialize)]
@@ -31,7 +32,8 @@ pub struct Split {
     pub team: Option<IdNameLink>,
     pub player: Option<Player>,
     // Game log fields (only present on gameLog splits):
-    pub date: Option<String>,
+    #[serde(default, with = "crate::serde_dates::optional_date")]
+    pub date: Option<NaiveDate>,
     pub is_home: Option<bool>,
     pub is_win: Option<bool>,
     pub opponent: Option<IdNameLink>,

--- a/api/src/team.rs
+++ b/api/src/team.rs
@@ -1,5 +1,5 @@
 use crate::live::{FullPlayer, PrimaryPosition};
-
+use chrono::NaiveDate;
 use serde::Deserialize;
 use std::fmt;
 
@@ -51,9 +51,12 @@ pub struct Transaction {
     pub person: Option<TransactionEntity>,
     pub from_team: Option<TransactionEntity>,
     pub to_team: Option<TransactionEntity>,
-    pub date: Option<String>,
-    pub effective_date: Option<String>,
-    pub resolution_date: Option<String>,
+    #[serde(default, with = "crate::serde_dates::optional_date")]
+    pub date: Option<NaiveDate>,
+    #[serde(default, with = "crate::serde_dates::optional_date")]
+    pub effective_date: Option<NaiveDate>,
+    #[serde(default, with = "crate::serde_dates::optional_date")]
+    pub resolution_date: Option<NaiveDate>,
     pub type_code: Option<String>,
     pub type_desc: Option<String>,
     pub description: Option<String>,

--- a/src/components/datetime.rs
+++ b/src/components/datetime.rs
@@ -1,18 +1,6 @@
 use chrono::{DateTime, NaiveDate, Utc};
 use chrono_tz::Tz;
 
-/// Parse a date in the API's `YYYY-MM-DD` form.
-pub fn parse_api_date(s: &str) -> Option<NaiveDate> {
-    NaiveDate::parse_from_str(s, "%Y-%m-%d").ok()
-}
-
-/// Parse an RFC 3339 datetime to UTC. Accepts any offset, not just `Z`.
-pub fn parse_api_datetime(s: &str) -> Option<DateTime<Utc>> {
-    DateTime::parse_from_rfc3339(s)
-        .ok()
-        .map(|dt| dt.with_timezone(&Utc))
-}
-
 /// Format a game start time in the configured timezone as "7:05 pm".
 pub fn format_game_time(utc: DateTime<Utc>, tz: Tz) -> String {
     utc.with_timezone(&tz).format("%-I:%M %P").to_string()
@@ -24,27 +12,25 @@ pub fn format_game_time_padded(utc: DateTime<Utc>, tz: Tz) -> String {
     utc.with_timezone(&tz).format("%l:%M %P").to_string()
 }
 
-/// Format an API-shaped `YYYY-MM-DD` string as "Apr 13". Returns `None` on parse failure.
-pub fn format_short_date(s: &str) -> Option<String> {
-    parse_api_date(s).map(|d| d.format("%b %-d").to_string())
+/// Format a date as "Apr 13".
+pub fn format_short_date(d: NaiveDate) -> String {
+    d.format("%b %-d").to_string()
 }
 
-/// Format an API-shaped `YYYY-MM-DD` string as "4/13/2026". Returns `None` on parse failure.
-pub fn format_numeric_date(s: &str) -> Option<String> {
-    parse_api_date(s).map(|d| d.format("%-m/%-d/%Y").to_string())
+/// Format a date as "4/13/2026".
+pub fn format_numeric_date(d: NaiveDate) -> String {
+    d.format("%-m/%-d/%Y").to_string()
 }
 
-/// Format an optional `YYYY-MM-DD` string as "Apr 13", or `fallback` for missing or unparseable
-/// input.
-pub fn format_short_date_or<S: AsRef<str>>(date: Option<&S>, fallback: &str) -> String {
-    date.and_then(|s| format_short_date(s.as_ref()))
+/// Format an optional date as "Apr 13", or `fallback` for `None`.
+pub fn format_short_date_or(date: Option<NaiveDate>, fallback: &str) -> String {
+    date.map(format_short_date)
         .unwrap_or_else(|| fallback.to_string())
 }
 
-/// Format an optional `YYYY-MM-DD` string as "4/13/2026", or `fallback` for missing or unparseable
-/// input.
-pub fn format_numeric_date_or<S: AsRef<str>>(date: Option<&S>, fallback: &str) -> String {
-    date.and_then(|s| format_numeric_date(s.as_ref()))
+/// Format an optional date as "4/13/2026", or `fallback` for `None`.
+pub fn format_numeric_date_or(date: Option<NaiveDate>, fallback: &str) -> String {
+    date.map(format_numeric_date)
         .unwrap_or_else(|| fallback.to_string())
 }
 
@@ -52,29 +38,6 @@ pub fn format_numeric_date_or<S: AsRef<str>>(date: Option<&S>, fallback: &str) -
 mod tests {
     use super::*;
     use chrono::TimeZone;
-
-    #[test]
-    fn parse_api_date_valid_and_invalid() {
-        assert_eq!(
-            parse_api_date("2026-04-13"),
-            NaiveDate::from_ymd_opt(2026, 4, 13)
-        );
-        assert_eq!(parse_api_date("not-a-date"), None);
-    }
-
-    #[test]
-    fn parse_api_datetime_various_formats() {
-        // Z suffix
-        let got = parse_api_datetime("2026-04-13T23:05:00Z").unwrap();
-        assert_eq!(got, Utc.with_ymd_and_hms(2026, 4, 13, 23, 5, 0).unwrap());
-
-        // Non-UTC offset yields the correct UTC instant
-        let got = parse_api_datetime("2026-04-13T19:05:00-04:00").unwrap();
-        assert_eq!(got, Utc.with_ymd_and_hms(2026, 4, 13, 23, 5, 0).unwrap());
-
-        // Invalid input
-        assert_eq!(parse_api_datetime("nope"), None);
-    }
 
     #[test]
     fn format_game_time_variants() {
@@ -96,30 +59,17 @@ mod tests {
 
     #[test]
     fn format_dates() {
-        assert_eq!(format_short_date("2026-04-13").as_deref(), Some("Apr 13"));
-        assert_eq!(
-            format_numeric_date("2026-04-13").as_deref(),
-            Some("4/13/2026")
-        );
-
-        // Parse failure yields None
-        assert_eq!(format_short_date("not-a-date"), None);
-        assert_eq!(format_numeric_date(""), None);
+        let d = NaiveDate::from_ymd_opt(2026, 4, 13).unwrap();
+        assert_eq!(format_short_date(d), "Apr 13");
+        assert_eq!(format_numeric_date(d), "4/13/2026");
     }
 
     #[test]
-    fn format_or_handles_missing_and_unparseable() {
-        let valid = String::from("2026-04-13");
-        assert_eq!(format_short_date_or(Some(&valid), "-"), "Apr 13");
-        assert_eq!(format_numeric_date_or(Some(&valid), "-"), "4/13/2026");
-
-        // Missing input falls back
-        assert_eq!(format_short_date_or::<String>(None, "-"), "-");
-        assert_eq!(format_numeric_date_or::<String>(None, "---"), "---");
-
-        // Unparseable input also falls back
-        let bad = String::from("not-a-date");
-        assert_eq!(format_short_date_or(Some(&bad), "-"), "-");
-        assert_eq!(format_numeric_date_or(Some(&bad), "---"), "---");
+    fn format_or_handles_missing() {
+        let d = NaiveDate::from_ymd_opt(2026, 4, 13).unwrap();
+        assert_eq!(format_short_date_or(Some(d), "-"), "Apr 13");
+        assert_eq!(format_numeric_date_or(Some(d), "-"), "4/13/2026");
+        assert_eq!(format_short_date_or(None, "-"), "-");
+        assert_eq!(format_numeric_date_or(None, "---"), "---");
     }
 }

--- a/src/components/datetime.rs
+++ b/src/components/datetime.rs
@@ -1,0 +1,125 @@
+use chrono::{DateTime, NaiveDate, Utc};
+use chrono_tz::Tz;
+
+/// Parse a date in the API's `YYYY-MM-DD` form.
+pub fn parse_api_date(s: &str) -> Option<NaiveDate> {
+    NaiveDate::parse_from_str(s, "%Y-%m-%d").ok()
+}
+
+/// Parse an RFC 3339 datetime to UTC. Accepts any offset, not just `Z`.
+pub fn parse_api_datetime(s: &str) -> Option<DateTime<Utc>> {
+    DateTime::parse_from_rfc3339(s)
+        .ok()
+        .map(|dt| dt.with_timezone(&Utc))
+}
+
+/// Format a game start time in the configured timezone as "7:05 pm".
+pub fn format_game_time(utc: DateTime<Utc>, tz: Tz) -> String {
+    utc.with_timezone(&tz).format("%-I:%M %P").to_string()
+}
+
+/// Same as `format_game_time`, but pads single-digit hours with a leading space (" 7:05 pm") for
+/// table column alignment.
+pub fn format_game_time_padded(utc: DateTime<Utc>, tz: Tz) -> String {
+    utc.with_timezone(&tz).format("%l:%M %P").to_string()
+}
+
+/// Format an API-shaped `YYYY-MM-DD` string as "Apr 13". Returns `None` on parse failure.
+pub fn format_short_date(s: &str) -> Option<String> {
+    parse_api_date(s).map(|d| d.format("%b %-d").to_string())
+}
+
+/// Format an API-shaped `YYYY-MM-DD` string as "4/13/2026". Returns `None` on parse failure.
+pub fn format_numeric_date(s: &str) -> Option<String> {
+    parse_api_date(s).map(|d| d.format("%-m/%-d/%Y").to_string())
+}
+
+/// Format an optional `YYYY-MM-DD` string as "Apr 13", or `fallback` for missing or unparseable
+/// input.
+pub fn format_short_date_or<S: AsRef<str>>(date: Option<&S>, fallback: &str) -> String {
+    date.and_then(|s| format_short_date(s.as_ref()))
+        .unwrap_or_else(|| fallback.to_string())
+}
+
+/// Format an optional `YYYY-MM-DD` string as "4/13/2026", or `fallback` for missing or unparseable
+/// input.
+pub fn format_numeric_date_or<S: AsRef<str>>(date: Option<&S>, fallback: &str) -> String {
+    date.and_then(|s| format_numeric_date(s.as_ref()))
+        .unwrap_or_else(|| fallback.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::TimeZone;
+
+    #[test]
+    fn parse_api_date_valid_and_invalid() {
+        assert_eq!(
+            parse_api_date("2026-04-13"),
+            NaiveDate::from_ymd_opt(2026, 4, 13)
+        );
+        assert_eq!(parse_api_date("not-a-date"), None);
+    }
+
+    #[test]
+    fn parse_api_datetime_various_formats() {
+        // Z suffix
+        let got = parse_api_datetime("2026-04-13T23:05:00Z").unwrap();
+        assert_eq!(got, Utc.with_ymd_and_hms(2026, 4, 13, 23, 5, 0).unwrap());
+
+        // Non-UTC offset yields the correct UTC instant
+        let got = parse_api_datetime("2026-04-13T19:05:00-04:00").unwrap();
+        assert_eq!(got, Utc.with_ymd_and_hms(2026, 4, 13, 23, 5, 0).unwrap());
+
+        // Invalid input
+        assert_eq!(parse_api_datetime("nope"), None);
+    }
+
+    #[test]
+    fn format_game_time_variants() {
+        // Single digit hour: padded version adds a leading space
+        let utc = Utc.with_ymd_and_hms(2026, 4, 13, 23, 5, 0).unwrap();
+        assert_eq!(format_game_time(utc, chrono_tz::US::Eastern), "7:05 pm");
+        assert_eq!(
+            format_game_time_padded(utc, chrono_tz::US::Eastern),
+            " 7:05 pm"
+        );
+
+        // Double digit hour: no padding difference
+        let utc = Utc.with_ymd_and_hms(2026, 4, 13, 14, 30, 0).unwrap();
+        assert_eq!(
+            format_game_time_padded(utc, chrono_tz::US::Eastern),
+            "10:30 am"
+        );
+    }
+
+    #[test]
+    fn format_dates() {
+        assert_eq!(format_short_date("2026-04-13").as_deref(), Some("Apr 13"));
+        assert_eq!(
+            format_numeric_date("2026-04-13").as_deref(),
+            Some("4/13/2026")
+        );
+
+        // Parse failure yields None
+        assert_eq!(format_short_date("not-a-date"), None);
+        assert_eq!(format_numeric_date(""), None);
+    }
+
+    #[test]
+    fn format_or_handles_missing_and_unparseable() {
+        let valid = String::from("2026-04-13");
+        assert_eq!(format_short_date_or(Some(&valid), "-"), "Apr 13");
+        assert_eq!(format_numeric_date_or(Some(&valid), "-"), "4/13/2026");
+
+        // Missing input falls back
+        assert_eq!(format_short_date_or::<String>(None, "-"), "-");
+        assert_eq!(format_numeric_date_or::<String>(None, "---"), "---");
+
+        // Unparseable input also falls back
+        let bad = String::from("not-a-date");
+        assert_eq!(format_short_date_or(Some(&bad), "-"), "-");
+        assert_eq!(format_numeric_date_or(Some(&bad), "---"), "---");
+    }
+}

--- a/src/components/mod.rs
+++ b/src/components/mod.rs
@@ -2,6 +2,7 @@ pub mod banner;
 pub mod boxscore;
 pub mod constants;
 pub mod date_selector;
+pub mod datetime;
 pub mod debug;
 pub mod decision_pitchers;
 pub mod game;

--- a/src/components/schedule.rs
+++ b/src/components/schedule.rs
@@ -1,9 +1,9 @@
 use crate::components::constants::lookup_team_or;
 use crate::components::date_selector::DateSelector;
+use crate::components::datetime::format_game_time_padded;
 use crate::components::decision_pitchers::GameDecisionPitchers;
 use crate::components::probable_pitchers::{ProbablePitcher, ProbablePitcherMatchup};
 use crate::components::standings::Team;
-use crate::components::util::format_start_time_table;
 use crate::state::app_settings::AppSettings;
 use crate::state::app_state::HomeOrAway;
 use chrono::{DateTime, NaiveDate, Utc};
@@ -137,7 +137,7 @@ impl ScheduleState {
     /// Called after the user changes timezone so times update without a schedule refetch.
     pub fn refresh_start_times(&mut self, tz: Tz) {
         for row in &mut self.schedule {
-            row.start_time = format_start_time_table(row.start_time_utc, tz);
+            row.start_time = format_game_time_padded(row.start_time_utc, tz);
         }
     }
 
@@ -246,7 +246,7 @@ impl ScheduleRow {
                 error!("invalid game_date {:?}: {err}", game.game_date);
                 DateTime::<Utc>::UNIX_EPOCH
             });
-        let start_time = format_start_time_table(start_time_utc, timezone);
+        let start_time = format_game_time_padded(start_time_utc, timezone);
 
         let game_status = match &game.status.detailed_state {
             Some(s) if s == "In Progress" => {

--- a/src/components/schedule.rs
+++ b/src/components/schedule.rs
@@ -9,7 +9,6 @@ use crate::state::app_state::HomeOrAway;
 use chrono::{DateTime, NaiveDate, Utc};
 use chrono_tz::Tz;
 use core::option::Option::{None, Some};
-use log::error;
 use mlbt_api::schedule::{Game, LeagueRecord, ScheduleResponse};
 use std::cmp::Ordering;
 use tui::widgets::TableState;
@@ -240,12 +239,7 @@ impl ScheduleRow {
         });
         let away_record = Record::from_league_record(away_team.league_record.as_ref());
 
-        let start_time_utc = DateTime::parse_from_rfc3339(&game.game_date)
-            .map(|dt| dt.with_timezone(&Utc))
-            .unwrap_or_else(|err| {
-                error!("invalid game_date {:?}: {err}", game.game_date);
-                DateTime::<Utc>::UNIX_EPOCH
-            });
+        let start_time_utc = game.game_date;
         let start_time = format_game_time_padded(start_time_utc, timezone);
 
         let game_status = match &game.status.detailed_state {

--- a/src/components/stats/player_profile.rs
+++ b/src/components/stats/player_profile.rs
@@ -1,8 +1,9 @@
 use crate::components::constants::{lookup_team, lookup_team_by_id};
+use crate::components::datetime::format_numeric_date_or;
 use crate::components::standings::Team;
 use crate::components::stats::splits::{RecentSplit, RecentStats, StatSplits};
 use crate::components::util::{
-    DimColor, OptionDisplayExt, OptionMapDisplayExt, avg_color, era_color, format_date,
+    DimColor, OptionDisplayExt, OptionMapDisplayExt, avg_color, era_color,
 };
 use mlbt_api::player::PersonFull;
 use mlbt_api::stats::{Split, StatSplit};
@@ -105,7 +106,7 @@ impl PlayerProfile {
         let weight = person.weight.map_display_or(|w| format!("{w}lb"), "");
         let age = person.current_age.display_or("-");
 
-        let birth_date = person.birth_date.map_display_or(|d| format_date(d), "---");
+        let birth_date = format_numeric_date_or(person.birth_date.as_ref(), "---");
         let birthplace = [
             person.birth_city.as_deref(),
             person.birth_state_province.as_deref(),
@@ -130,9 +131,7 @@ impl PlayerProfile {
             ));
         }
 
-        let mlb_debut = person
-            .mlb_debut_date
-            .map_display_or(|d| format_date(d), "---");
+        let mlb_debut = format_numeric_date_or(person.mlb_debut_date.as_ref(), "---");
 
         let mut bio = vec![
             format!("{position} | {bats}/{throws} | {height} {weight} | Age: {age}").into(),
@@ -213,7 +212,7 @@ impl PlayerProfile {
     }
 
     fn game_log_cells(split: &Split) -> Vec<Cell<'_>> {
-        let date = split.date.map_display_or(|d| format_date(d), "");
+        let date = format_numeric_date_or(split.date.as_ref(), "");
         let opp = split
             .opponent
             .map_display_or(|o| lookup_team(&o.name).abbreviation, "---");

--- a/src/components/stats/player_profile.rs
+++ b/src/components/stats/player_profile.rs
@@ -106,7 +106,7 @@ impl PlayerProfile {
         let weight = person.weight.map_display_or(|w| format!("{w}lb"), "");
         let age = person.current_age.display_or("-");
 
-        let birth_date = format_numeric_date_or(person.birth_date.as_ref(), "---");
+        let birth_date = format_numeric_date_or(person.birth_date, "---");
         let birthplace = [
             person.birth_city.as_deref(),
             person.birth_state_province.as_deref(),
@@ -131,7 +131,7 @@ impl PlayerProfile {
             ));
         }
 
-        let mlb_debut = format_numeric_date_or(person.mlb_debut_date.as_ref(), "---");
+        let mlb_debut = format_numeric_date_or(person.mlb_debut_date, "---");
 
         let mut bio = vec![
             format!("{position} | {bats}/{throws} | {height} {weight} | Age: {age}").into(),
@@ -212,7 +212,7 @@ impl PlayerProfile {
     }
 
     fn game_log_cells(split: &Split) -> Vec<Cell<'_>> {
-        let date = format_numeric_date_or(split.date.as_ref(), "");
+        let date = format_numeric_date_or(split.date, "");
         let opp = split
             .opponent
             .map_display_or(|o| lookup_team(&o.name).abbreviation, "---");

--- a/src/components/team_page.rs
+++ b/src/components/team_page.rs
@@ -1,7 +1,6 @@
 use crate::components::constants::lookup_team_by_id;
 use crate::components::datetime::{
     format_game_time, format_numeric_date_or, format_short_date, format_short_date_or,
-    parse_api_date, parse_api_datetime,
 };
 use crate::components::util::{OptionDisplayExt, OptionMapDisplayExt};
 use chrono::{DateTime, NaiveDate, Utc};
@@ -71,19 +70,15 @@ impl TeamGame {
                     format!("@ {abbr}")
                 };
 
-                let game_date = parse_api_date(&game.official_date).unwrap_or_default();
-                let date_display = format_short_date(&game.official_date).unwrap_or_default();
+                let game_date = game.official_date;
+                let date_display = format_short_date(game_date);
 
                 let is_final = matches!(
                     game.status.abstract_game_state,
                     Some(AbstractGameState::Final)
                 );
                 let is_past = is_final && game_date < date;
-                let start_time_utc = if is_final {
-                    None
-                } else {
-                    parse_api_datetime(&game.game_date)
-                };
+                let start_time_utc = if is_final { None } else { Some(game.game_date) };
 
                 let time_or_score = if is_final {
                     let home_score = game.teams.home.score.unwrap_or(0);
@@ -190,7 +185,7 @@ impl RosterRow {
                     bats_throws: format!("{bats}/{throws}"),
                     height: person.height.display_or("-"),
                     weight: person.weight.display_or("-"),
-                    dob: format_numeric_date_or(person.birth_date.as_ref(), "-"),
+                    dob: format_numeric_date_or(person.birth_date, "-"),
                     status: entry.status.description.clone(),
                     status_code: entry.status.code.clone(),
                 }
@@ -217,7 +212,7 @@ impl TransactionRow {
             .iter()
             .filter_map(|t| {
                 let description = t.description.clone()?;
-                let date = format_short_date_or(t.date.as_ref(), "");
+                let date = format_short_date_or(t.date, "");
                 Some(TransactionRow { date, description })
             })
             .collect();

--- a/src/components/team_page.rs
+++ b/src/components/team_page.rs
@@ -1,8 +1,10 @@
 use crate::components::constants::lookup_team_by_id;
-use crate::components::util::{
-    OptionDisplayExt, OptionMapDisplayExt, format_date, format_start_time_compact,
+use crate::components::datetime::{
+    format_game_time, format_numeric_date_or, format_short_date, format_short_date_or,
+    parse_api_date, parse_api_datetime,
 };
-use chrono::{DateTime, NaiveDate, NaiveDateTime, TimeZone, Utc};
+use crate::components::util::{OptionDisplayExt, OptionMapDisplayExt};
+use chrono::{DateTime, NaiveDate, Utc};
 use chrono_tz::Tz;
 use mlbt_api::schedule::{AbstractGameState, ScheduleResponse};
 use mlbt_api::team::{RosterResponse, TransactionsResponse};
@@ -69,9 +71,8 @@ impl TeamGame {
                     format!("@ {abbr}")
                 };
 
-                let game_date =
-                    NaiveDate::parse_from_str(&game.official_date, "%Y-%m-%d").unwrap_or_default();
-                let date_display = format_short_date(&game.official_date);
+                let game_date = parse_api_date(&game.official_date).unwrap_or_default();
+                let date_display = format_short_date(&game.official_date).unwrap_or_default();
 
                 let is_final = matches!(
                     game.status.abstract_game_state,
@@ -81,7 +82,7 @@ impl TeamGame {
                 let start_time_utc = if is_final {
                     None
                 } else {
-                    parse_game_time(&game.game_date)
+                    parse_api_datetime(&game.game_date)
                 };
 
                 let time_or_score = if is_final {
@@ -102,7 +103,7 @@ impl TeamGame {
                     format!("{team_score}-{opp_score} {result}")
                 } else {
                     start_time_utc
-                        .map(|utc| format_start_time_compact(utc, tz))
+                        .map(|utc| format_game_time(utc, tz))
                         .unwrap_or_else(|| "TBD".to_string())
                 };
 
@@ -122,7 +123,7 @@ impl TeamGame {
 
     pub fn refresh_time_or_score(&mut self, tz: Tz) {
         if let Some(utc) = self.start_time_utc {
-            self.time_or_score = format_start_time_compact(utc, tz);
+            self.time_or_score = format_game_time(utc, tz);
         }
     }
 }
@@ -189,10 +190,7 @@ impl RosterRow {
                     bats_throws: format!("{bats}/{throws}"),
                     height: person.height.display_or("-"),
                     weight: person.weight.display_or("-"),
-                    dob: person
-                        .birth_date
-                        .as_ref()
-                        .map_display_or(|d| format_date(d), "-"),
+                    dob: format_numeric_date_or(person.birth_date.as_ref(), "-"),
                     status: entry.status.description.clone(),
                     status_code: entry.status.code.clone(),
                 }
@@ -219,7 +217,7 @@ impl TransactionRow {
             .iter()
             .filter_map(|t| {
                 let description = t.description.clone()?;
-                let date = t.date.as_ref().map_display_or(|d| format_short_date(d), "");
+                let date = format_short_date_or(t.date.as_ref(), "");
                 Some(TransactionRow { date, description })
             })
             .collect();
@@ -227,17 +225,4 @@ impl TransactionRow {
         rows.reverse();
         rows
     }
-}
-
-/// Parse "YYYY-MM-DD" into a short display like "Mar 26", or return the input on failure.
-fn format_short_date(s: &str) -> String {
-    NaiveDate::parse_from_str(s, "%Y-%m-%d")
-        .map(|d| d.format("%b %-d").to_string())
-        .unwrap_or_else(|_| s.to_string())
-}
-
-fn parse_game_time(game_date: &str) -> Option<DateTime<Utc>> {
-    NaiveDateTime::parse_from_str(game_date, "%Y-%m-%dT%H:%M:%SZ")
-        .ok()
-        .map(|ndt| Utc.from_utc_datetime(&ndt))
 }

--- a/src/components/util.rs
+++ b/src/components/util.rs
@@ -1,5 +1,3 @@
-use chrono::{DateTime, NaiveDate, Utc};
-use chrono_tz::Tz;
 use log::error;
 use tui::style::Color;
 
@@ -79,23 +77,6 @@ pub(crate) fn last_name(full: &str) -> &str {
     } else {
         tail
     }
-}
-
-/// Format "YYYY-MM-DD" as "M/D/YYYY", or return the original string if parsing fails.
-pub(crate) fn format_date(s: &str) -> String {
-    NaiveDate::parse_from_str(s, "%Y-%m-%d")
-        .map(|d| d.format("%-m/%-d/%Y").to_string())
-        .unwrap_or_else(|_| s.to_string())
-}
-
-/// Format a UTC game start time for schedule/table display in the user's configured timezone.
-pub(crate) fn format_start_time_table(utc: DateTime<Utc>, tz: Tz) -> String {
-    utc.with_timezone(&tz).format("%l:%M %P").to_string()
-}
-
-/// Format a UTC game start time for compact display in the user's configured timezone.
-pub(crate) fn format_start_time_compact(utc: DateTime<Utc>, tz: Tz) -> String {
-    utc.with_timezone(&tz).format("%-I:%M %P").to_string()
 }
 
 /// Color for an ERA stat string. Returns `None` for average range (3.00–4.99) so

--- a/src/state/cache.rs
+++ b/src/state/cache.rs
@@ -275,8 +275,6 @@ mod tests {
     use mlbt_api::season::GameType;
     use std::sync::Arc;
 
-    const TEST_DATE: &str = "2026-04-13";
-
     fn test_date() -> NaiveDate {
         NaiveDate::from_ymd_opt(2026, 4, 13).unwrap()
     }
@@ -336,11 +334,11 @@ mod tests {
         assert!(NetworkCache::key_for(&req).is_none());
     }
 
-    fn make_schedule(date: &str, games: Vec<(u64, AbstractGameState)>) -> ScheduleResponse {
+    fn make_schedule(date: NaiveDate, games: Vec<(u64, AbstractGameState)>) -> ScheduleResponse {
         use mlbt_api::schedule::{Dates, Game, Status};
         ScheduleResponse {
             dates: vec![Dates {
-                date: Some(date.to_string()),
+                date: Some(date),
                 games: Some(
                     games
                         .into_iter()
@@ -382,7 +380,7 @@ mod tests {
         );
 
         // First schedule: game is Live
-        let schedule = make_schedule(TEST_DATE, vec![(game_id, AbstractGameState::Live)]);
+        let schedule = make_schedule(test_date(), vec![(game_id, AbstractGameState::Live)]);
         cache.update_game_states(test_date(), &schedule);
         assert_eq!(
             cache.entries[&CacheKey::GameData { game_id }].ttl,
@@ -390,7 +388,7 @@ mod tests {
         );
 
         // Game goes Final
-        let schedule = make_schedule(TEST_DATE, vec![(game_id, AbstractGameState::Final)]);
+        let schedule = make_schedule(test_date(), vec![(game_id, AbstractGameState::Final)]);
         cache.update_game_states(test_date(), &schedule);
         assert_eq!(
             cache.entries[&CacheKey::GameData { game_id }].ttl,
@@ -422,9 +420,9 @@ mod tests {
         assert!(cache.get(&CacheKey::Standings { date }).is_some());
 
         // Game goes from Live to Final
-        let schedule = make_schedule(TEST_DATE, vec![(123, AbstractGameState::Live)]);
+        let schedule = make_schedule(test_date(), vec![(123, AbstractGameState::Live)]);
         cache.update_game_states(test_date(), &schedule);
-        let schedule = make_schedule(TEST_DATE, vec![(123, AbstractGameState::Final)]);
+        let schedule = make_schedule(test_date(), vec![(123, AbstractGameState::Final)]);
         cache.update_game_states(test_date(), &schedule);
 
         // Standings and stats should be invalidated
@@ -445,7 +443,7 @@ mod tests {
         let date = NaiveDate::from_ymd_opt(2026, 4, 13).unwrap();
 
         // Game already Final
-        let schedule = make_schedule(TEST_DATE, vec![(123, AbstractGameState::Final)]);
+        let schedule = make_schedule(test_date(), vec![(123, AbstractGameState::Final)]);
         cache.update_game_states(test_date(), &schedule);
 
         // Cache standings after the game went Final
@@ -475,7 +473,7 @@ mod tests {
 
         // Game appears for the first time as Final. No prior state and no mutable date observed.
         // This is likely historical browsing so current caches are not assumed stale.
-        let schedule = make_schedule(TEST_DATE, vec![(456, AbstractGameState::Final)]);
+        let schedule = make_schedule(test_date(), vec![(456, AbstractGameState::Final)]);
         cache.update_game_states(test_date(), &schedule);
 
         assert!(cache.get(&CacheKey::Standings { date }).is_some());
@@ -497,7 +495,7 @@ mod tests {
         );
 
         // Game goes Final — should reset fetched_at to now
-        let schedule = make_schedule(TEST_DATE, vec![(game_id, AbstractGameState::Final)]);
+        let schedule = make_schedule(test_date(), vec![(game_id, AbstractGameState::Final)]);
         cache.update_game_states(test_date(), &schedule);
 
         let entry = &cache.entries[&CacheKey::GameData { game_id }];
@@ -597,7 +595,7 @@ mod tests {
 
         // User browses back to a past date so all games there are already Final.
         // We've never observed game 123 nor the past date in a non final state.
-        let schedule = make_schedule("2026-04-10", vec![(123, AbstractGameState::Final)]);
+        let schedule = make_schedule(past, vec![(123, AbstractGameState::Final)]);
         cache.update_game_states(past, &schedule);
 
         // No evidence the cached standings are stale.
@@ -621,7 +619,7 @@ mod tests {
             .mutable_dates
             .insert(past, Instant::now() - PRUNE_AGE - Duration::from_secs(1));
 
-        let schedule = make_schedule("2026-04-10", vec![(123, AbstractGameState::Final)]);
+        let schedule = make_schedule(past, vec![(123, AbstractGameState::Final)]);
         cache.update_game_states(past, &schedule);
 
         assert!(cache.get(&CacheKey::Standings { date: today }).is_some());
@@ -640,11 +638,11 @@ mod tests {
         );
 
         // Observe the game as Live first (establishes that we watched this date mutable)
-        let schedule = make_schedule(TEST_DATE, vec![(123, AbstractGameState::Live)]);
+        let schedule = make_schedule(test_date(), vec![(123, AbstractGameState::Live)]);
         cache.update_game_states(date, &schedule);
 
         // Then observe the transition to Final.  This is a real signal
-        let schedule = make_schedule(TEST_DATE, vec![(123, AbstractGameState::Final)]);
+        let schedule = make_schedule(test_date(), vec![(123, AbstractGameState::Final)]);
         cache.update_game_states(date, &schedule);
 
         assert!(cache.get(&CacheKey::Standings { date }).is_none());
@@ -667,9 +665,9 @@ mod tests {
         }
 
         // Game on Apr 13 goes Final
-        let schedule = make_schedule(TEST_DATE, vec![(123, AbstractGameState::Live)]);
+        let schedule = make_schedule(test_date(), vec![(123, AbstractGameState::Live)]);
         cache.update_game_states(test_date(), &schedule);
-        let schedule = make_schedule(TEST_DATE, vec![(123, AbstractGameState::Final)]);
+        let schedule = make_schedule(test_date(), vec![(123, AbstractGameState::Final)]);
         cache.update_game_states(test_date(), &schedule);
 
         // Earlier date preserved, transition date and later invalidated
@@ -725,7 +723,7 @@ mod tests {
         };
         let schedule = ScheduleResponse {
             dates: vec![Dates {
-                date: Some(TEST_DATE.to_string()),
+                date: Some(test_date()),
                 games: Some(vec![make_game(AbstractGameState::Live)]),
                 ..Default::default()
             }],
@@ -736,7 +734,7 @@ mod tests {
         // Now the game goes Final
         let schedule = ScheduleResponse {
             dates: vec![Dates {
-                date: Some(TEST_DATE.to_string()),
+                date: Some(test_date()),
                 games: Some(vec![make_game(AbstractGameState::Final)]),
                 ..Default::default()
             }],
@@ -767,11 +765,11 @@ mod tests {
         let mut cache = NetworkCache::new();
         assert!(!cache.is_final_game(42));
 
-        let schedule = make_schedule(TEST_DATE, vec![(42, AbstractGameState::Live)]);
+        let schedule = make_schedule(test_date(), vec![(42, AbstractGameState::Live)]);
         cache.update_game_states(test_date(), &schedule);
         assert!(!cache.is_final_game(42));
 
-        let schedule = make_schedule(TEST_DATE, vec![(42, AbstractGameState::Final)]);
+        let schedule = make_schedule(test_date(), vec![(42, AbstractGameState::Final)]);
         cache.update_game_states(test_date(), &schedule);
         assert!(cache.is_final_game(42));
     }


### PR DESCRIPTION
- datetime handling was all over the place
- this improves it by moving API models from string dates to strongly typed `chrono::NaiveDate` and `chrono::DateTime` fields
- additionally, centralized all date related helper functions, which are now just formatters (instead of also being parsers)