### PR TITLE
Stop `cargo test` from overwriting mlbt.toml

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -353,10 +353,13 @@ mod tests {
     use tui::widgets::TableState;
 
     fn test_app() -> App {
+        // tests must never share the real config file path, otherwise running the suite would
+        // overwrite the local `mlbt.toml` with default settings on every save call
+        let path = std::env::temp_dir().join(format!("mlbt-test-{}.toml", std::process::id()));
         App {
             settings: AppSettings::from(ConfigFile::default()),
             state: AppState::default(),
-            store: TomlFileStore::default(),
+            store: TomlFileStore::with_path(path),
         }
     }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -103,6 +103,12 @@ impl TomlFileStore {
     const HEADER: &str = "# See https://github.com/mlb-rs/mlbt#config for options\n";
     const CONFIG_FILE_NAME: &str = "mlbt.toml";
 
+    /// Build a store backed by a specific path. Used in tests so the real config file isn't clobbered.
+    #[cfg(test)]
+    pub fn with_path(path: PathBuf) -> Self {
+        Self { path: Some(path) }
+    }
+
     /// Resolve the canonical config path:
     /// * Linux:   /home/alice/.config/mlbt/mlbt.toml
     /// * Windows: C:\Users\Alice\AppData\Roaming\mlbt\mlbt.toml


### PR DESCRIPTION
well, that was dumb and took me too long to figure out