### PR TITLE
Add _exclaimation point_ shortcut to show only scoring plays

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,6 +204,7 @@ To view different at bats in the game, use:
 | `k` / `↑` | move to next at bat                            |
 | `l`       | move to the "live" at bat, or latest available |
 | `s`       | move to first at bat of the game               |
+| `!`       | toggle scoring-plays-only filter               |
 
 To interact with the box score, use:
 

--- a/src/keys.rs
+++ b/src/keys.rs
@@ -212,6 +212,7 @@ pub async fn handle_key_bindings(
         (MenuItem::Gameday, Char('k') | KeyCode::Up, _) => guard.state.gameday.next_at_bat(),
         (MenuItem::Gameday, Char('l'), _) => guard.state.gameday.live(),
         (MenuItem::Gameday, Char('s'), _) => guard.state.gameday.start(),
+        (MenuItem::Gameday, Char('!'), _) => guard.state.gameday.toggle_scoring_plays_only(),
 
         (MenuItem::Gameday, Char('h'), _) => guard.state.box_score.set_home_active(),
         (MenuItem::Gameday, Char('a'), _) => guard.state.box_score.set_away_active(),

--- a/src/state/gameday.rs
+++ b/src/state/gameday.rs
@@ -5,6 +5,7 @@ use mlbt_api::schedule::AbstractGameState;
 pub struct GamedayState {
     pub panels: GamedayPanels,
     pub game: GameState,
+    pub scoring_plays_only: bool,
     selected_at_bat: Option<usize>,
 }
 
@@ -85,6 +86,10 @@ impl GamedayState {
 
     pub fn toggle_win_probability(&mut self) {
         self.panels.win_probability = !self.panels.win_probability;
+    }
+
+    pub fn toggle_scoring_plays_only(&mut self) {
+        self.scoring_plays_only = !self.scoring_plays_only;
     }
 }
 

--- a/src/ui/gameday/gameday_widget.rs
+++ b/src/ui/gameday/gameday_widget.rs
@@ -67,6 +67,7 @@ impl Widget for GamedayWidget<'_> {
             let innings_widget = InningPlaysWidget {
                 game: &self.state.game,
                 selected_at_bat: self.state.selected_at_bat(),
+                scoring_only: self.state.scoring_plays_only,
             };
             Widget::render(innings_widget, chunks[0], buf);
 

--- a/src/ui/gameday/plays.rs
+++ b/src/ui/gameday/plays.rs
@@ -18,12 +18,13 @@ pub const SELECTION_SYMBOL: char = '>';
 pub struct InningPlaysWidget<'a> {
     pub game: &'a GameState,
     pub selected_at_bat: Option<u8>,
+    pub scoring_only: bool,
 }
 
 impl Widget for InningPlaysWidget<'_> {
     fn render(self, area: Rect, buf: &mut Buffer) {
         // TODO this doesn't scroll properly. needs to be a list for that
-        let inning_plays = format_plays(self.game, self.selected_at_bat);
+        let inning_plays = format_plays(self.game, self.selected_at_bat, self.scoring_only);
         let paragraph = Paragraph::new(inning_plays).wrap(Wrap { trim: false });
 
         Widget::render(paragraph, area, buf);
@@ -31,7 +32,11 @@ impl Widget for InningPlaysWidget<'_> {
 }
 
 /// Format the plays for the current inning as TUI Lines.
-fn format_plays(game: &GameState, selected_at_bat: Option<u8>) -> Vec<Line<'_>> {
+fn format_plays(
+    game: &GameState,
+    selected_at_bat: Option<u8>,
+    scoring_only: bool,
+) -> Vec<Line<'_>> {
     let (at_bat, _is_current) = game.get_at_bat_by_index_or_current(selected_at_bat);
     let inning = at_bat.inning;
 
@@ -46,7 +51,11 @@ fn format_plays(game: &GameState, selected_at_bat: Option<u8>) -> Vec<Line<'_>> 
 
     for play in game.at_bats.values().rev() {
         let current_inning = (play.is_top_inning, play.inning);
-        if play.inning != inning {
+        if scoring_only {
+            if !play.play_result.is_scoring_play {
+                continue;
+            }
+        } else if play.inning != inning {
             continue;
         }
 


### PR DESCRIPTION
Hello again!

I like looking at only the scoring plays, so I added "!" to filter and show only scoring plays.

I used "!" because 's' and 'f' are taken. 🤷‍♂️


<img width="1359" height="850" alt="Screenshot 2026-06-30 at 21 27 13" src="https://github.com/user-attachments/assets/a5d8814c-ba56-4bd2-b820-e1188e256f42" />
