### PR TITLE
Add auto update for date

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.4.0]
+## [Unreleased]
+
+### Added
+
+- Add auto-advance date logic if app is open overnight: [PR 147](https://github.com/mlb-rs/mlbt/pull/147)
+
+## [0.4.0] - 2026-04-29
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Add auto-advance date logic if app is open overnight: [PR 147](https://github.com/mlb-rs/mlbt/pull/147)
+- Add auto-advance date logic if app is open overnight: [PR 146](https://github.com/mlb-rs/mlbt/pull/146)
 
 ## [0.4.0] - 2026-04-29
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1453,7 +1453,7 @@ dependencies = [
 
 [[package]]
 name = "mlbt"
-version = "0.4.0"
+version = "0.5.0-alpha.1"
 dependencies = [
  "anyhow",
  "better-panic",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mlbt"
-version = "0.4.0"
+version = "0.5.0-alpha.1"
 authors = ["Andrew Schneider <andjschneider@gmail.com>"]
 edition = "2024"
 license = "MIT"

--- a/README.md
+++ b/README.md
@@ -379,6 +379,9 @@ The config file is located at:
   [tz database](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones).
 - `log_level`: one of `off`, `error`, `warn`, `info`, `debug`, `trace`.
   Default is `error`.
+- `auto_advance_date`: when `true`, any date-driven tab sitting on today rolls
+  over to the new day automatically while the app is open. Tabs on a past date
+  are left untouched. Default is `true`.
 
 ### Example config
 
@@ -387,6 +390,7 @@ The config file is located at:
 favorite_team = "Chicago Cubs"
 timezone = "US/Pacific"
 log_level = "error"
+auto_advance_date = true
 ```
 
 ## Shout out

--- a/src/app.rs
+++ b/src/app.rs
@@ -1,6 +1,7 @@
 use crate::config::TomlFileStore;
 use crate::state::app_settings::AppSettings;
 use crate::state::app_state::AppState;
+use crate::state::messages::NetworkRequest;
 use crate::state::settings_editor::SettingsStatus;
 use chrono::{NaiveDate, ParseError, Utc};
 use log::{error, info};
@@ -132,6 +133,47 @@ impl App {
         self.state.schedule.date_selector.date = today;
         self.state.stats.date_selector.date = today;
         self.state.standings.date_selector.date = today;
+        self.state.last_known_today = Some(today);
+    }
+
+    /// Advance any date selector sitting on the current day to the new day when the system date
+    /// rolls over. A selector parked on a past date is left alone so the user keeps their place.
+    /// Returns a force refresh request for each tab that advanced so its data reloads.
+    pub fn advance_dates_on_rollover(&mut self) -> Vec<NetworkRequest> {
+        if !self.settings.auto_advance_date {
+            return Vec::new();
+        }
+
+        let today = Utc::now()
+            .with_timezone(&self.settings.timezone)
+            .date_naive();
+        // None means this is the first check, so just record today and wait for the next day.
+        let Some(previous) = self.state.last_known_today else {
+            self.state.last_known_today = Some(today);
+            return Vec::new();
+        };
+        if today == previous {
+            return Vec::new();
+        }
+        self.state.last_known_today = Some(today);
+
+        let mut requests = Vec::new();
+        if self.state.schedule.date_selector.date == previous {
+            self.state.schedule.set_date_from_valid_input(today);
+            requests.push(NetworkRequest::Schedule { date: today });
+        }
+        if self.state.standings.date_selector.date == previous {
+            self.state.standings.set_date_from_valid_input(today);
+            requests.push(NetworkRequest::Standings { date: today });
+        }
+        if self.state.stats.date_selector.date == previous {
+            self.state.stats.set_date_from_valid_input(today);
+            requests.push(NetworkRequest::Stats {
+                date: today,
+                stat_type: self.state.stats.stat_type,
+            });
+        }
+        requests
     }
 
     /// Update the schedule and return the selected game.
@@ -431,6 +473,74 @@ mod tests {
         assert_eq!(app.state.schedule.date_selector.date, historical_date);
         assert_eq!(app.state.stats.date_selector.date, historical_date);
         assert_eq!(app.state.standings.date_selector.date, historical_date);
+    }
+
+    #[test]
+    fn rollover_advances_only_selectors_on_the_current_day() {
+        let mut app = test_app();
+        let today = Utc::now()
+            .with_timezone(&app.settings.timezone)
+            .date_naive();
+        let previous = today - chrono::Duration::days(1);
+        let pinned = today - chrono::Duration::days(10);
+
+        // schedule and stats are sitting on "today" (the previous reference day), standings is
+        // pinned to a past date the user navigated to
+        app.state.last_known_today = Some(previous);
+        app.state.schedule.date_selector.date = previous;
+        app.state.stats.date_selector.date = previous;
+        app.state.standings.date_selector.date = pinned;
+
+        let requests = app.advance_dates_on_rollover();
+
+        assert_eq!(app.state.schedule.date_selector.date, today);
+        assert_eq!(app.state.stats.date_selector.date, today);
+        assert_eq!(app.state.standings.date_selector.date, pinned);
+        assert_eq!(app.state.last_known_today, Some(today));
+        // one request each for the two advanced tabs, none for the pinned standings
+        assert_eq!(requests.len(), 2);
+        assert!(
+            requests
+                .iter()
+                .all(|r| !matches!(r, NetworkRequest::Standings { .. }))
+        );
+    }
+
+    #[test]
+    fn rollover_is_a_noop_when_disabled_or_same_day() {
+        let mut app = test_app();
+        let today = Utc::now()
+            .with_timezone(&app.settings.timezone)
+            .date_naive();
+        let previous = today - chrono::Duration::days(1);
+
+        // disabled: nothing advances even though the day changed
+        app.settings.auto_advance_date = false;
+        app.state.last_known_today = Some(previous);
+        app.state.schedule.date_selector.date = previous;
+        assert!(app.advance_dates_on_rollover().is_empty());
+        assert_eq!(app.state.schedule.date_selector.date, previous);
+
+        // enabled but already on today: no work to do
+        app.settings.auto_advance_date = true;
+        app.state.last_known_today = Some(today);
+        app.state.schedule.date_selector.date = today;
+        assert!(app.advance_dates_on_rollover().is_empty());
+        assert_eq!(app.state.schedule.date_selector.date, today);
+    }
+
+    #[test]
+    fn rollover_seeds_last_known_today_on_first_check() {
+        let mut app = test_app();
+        assert_eq!(app.state.last_known_today, None);
+        let today = Utc::now()
+            .with_timezone(&app.settings.timezone)
+            .date_naive();
+
+        let requests = app.advance_dates_on_rollover();
+
+        assert!(requests.is_empty());
+        assert_eq!(app.state.last_known_today, Some(today));
     }
 
     #[test]

--- a/src/app.rs
+++ b/src/app.rs
@@ -133,29 +133,30 @@ impl App {
         self.state.schedule.date_selector.date = today;
         self.state.stats.date_selector.date = today;
         self.state.standings.date_selector.date = today;
-        self.state.last_known_today = Some(today);
     }
 
-    /// Advance any date selector sitting on the current day to the new day when the system date
-    /// rolls over. A selector parked on a past date is left alone so the user keeps their place.
-    /// Returns a force refresh request for each tab that advanced so its data reloads.
-    pub fn advance_dates_on_rollover(&mut self) -> Vec<NetworkRequest> {
-        if !self.settings.auto_advance_date {
-            return Vec::new();
-        }
-
+    /// Advance any date selector still on the current day to the new day after the system date
+    /// rolls over. Selectors parked on a past date are left untouched. `previous` is the day seen
+    /// on the last check (`None` on the first). Returns today plus a force refresh request for each
+    /// tab that advanced.
+    pub fn advance_dates_on_rollover(
+        &mut self,
+        previous: Option<NaiveDate>,
+    ) -> (NaiveDate, Vec<NetworkRequest>) {
         let today = Utc::now()
             .with_timezone(&self.settings.timezone)
             .date_naive();
-        // None means this is the first check, so just record today and wait for the next day.
-        let Some(previous) = self.state.last_known_today else {
-            self.state.last_known_today = Some(today);
-            return Vec::new();
+
+        if !self.settings.auto_advance_date {
+            return (today, Vec::new());
+        }
+        // None means this is the first check, so just report today and wait for the next day.
+        let Some(previous) = previous else {
+            return (today, Vec::new());
         };
         if today == previous {
-            return Vec::new();
+            return (today, Vec::new());
         }
-        self.state.last_known_today = Some(today);
 
         let mut requests = Vec::new();
         if self.state.schedule.date_selector.date == previous {
@@ -173,7 +174,7 @@ impl App {
                 stat_type: self.state.stats.stat_type,
             });
         }
-        requests
+        (today, requests)
     }
 
     /// Update the schedule and return the selected game.
@@ -486,17 +487,16 @@ mod tests {
 
         // schedule and stats are sitting on "today" (the previous reference day), standings is
         // pinned to a past date the user navigated to
-        app.state.last_known_today = Some(previous);
         app.state.schedule.date_selector.date = previous;
         app.state.stats.date_selector.date = previous;
         app.state.standings.date_selector.date = pinned;
 
-        let requests = app.advance_dates_on_rollover();
+        let (reported, requests) = app.advance_dates_on_rollover(Some(previous));
 
         assert_eq!(app.state.schedule.date_selector.date, today);
         assert_eq!(app.state.stats.date_selector.date, today);
         assert_eq!(app.state.standings.date_selector.date, pinned);
-        assert_eq!(app.state.last_known_today, Some(today));
+        assert_eq!(reported, today);
         // one request each for the two advanced tabs, none for the pinned standings
         assert_eq!(requests.len(), 2);
         assert!(
@@ -516,31 +516,36 @@ mod tests {
 
         // disabled: nothing advances even though the day changed
         app.settings.auto_advance_date = false;
-        app.state.last_known_today = Some(previous);
         app.state.schedule.date_selector.date = previous;
-        assert!(app.advance_dates_on_rollover().is_empty());
+        let (reported, requests) = app.advance_dates_on_rollover(Some(previous));
+        assert_eq!(reported, today);
+        assert!(requests.is_empty());
         assert_eq!(app.state.schedule.date_selector.date, previous);
 
         // enabled but already on today: no work to do
         app.settings.auto_advance_date = true;
-        app.state.last_known_today = Some(today);
         app.state.schedule.date_selector.date = today;
-        assert!(app.advance_dates_on_rollover().is_empty());
+        let (reported, requests) = app.advance_dates_on_rollover(Some(today));
+        assert_eq!(reported, today);
+        assert!(requests.is_empty());
         assert_eq!(app.state.schedule.date_selector.date, today);
     }
 
     #[test]
-    fn rollover_seeds_last_known_today_on_first_check() {
+    fn rollover_reports_today_without_advancing_on_first_check() {
         let mut app = test_app();
-        assert_eq!(app.state.last_known_today, None);
         let today = Utc::now()
             .with_timezone(&app.settings.timezone)
             .date_naive();
+        let previous = today - chrono::Duration::days(1);
+        app.state.schedule.date_selector.date = previous;
 
-        let requests = app.advance_dates_on_rollover();
+        // previous is None on the very first check: report today but advance nothing yet
+        let (reported, requests) = app.advance_dates_on_rollover(None);
 
+        assert_eq!(reported, today);
         assert!(requests.is_empty());
-        assert_eq!(app.state.last_known_today, Some(today));
+        assert_eq!(app.state.schedule.date_selector.date, previous);
     }
 
     #[test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -12,6 +12,7 @@ use std::sync::OnceLock;
 static CONFIG_FILE_LOCATION: OnceLock<Option<PathBuf>> = OnceLock::new();
 pub const DEFAULT_TIMEZONE: Tz = US__Pacific;
 pub const DEFAULT_LOG_LEVEL: LogLevel = LogLevel::Error;
+pub const DEFAULT_AUTO_ADVANCE_DATE: bool = true;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize, Serialize)]
 #[serde(rename_all = "lowercase")]
@@ -45,6 +46,10 @@ pub struct ConfigFile {
     /// Optional log level to use. If not present, the default is `Error`.
     /// Set the level using a lowercase string, e.g. "error".
     pub log_level: Option<LogLevel>,
+
+    /// Automatically advance any date-driven tab to the new day when the system date rolls over,
+    /// unless the tab selected a past date. Defaults to true.
+    pub auto_advance_date: Option<bool>,
 }
 
 impl Default for ConfigFile {
@@ -53,6 +58,7 @@ impl Default for ConfigFile {
             favorite_team: None,
             timezone: Some(DEFAULT_TIMEZONE),
             log_level: Some(DEFAULT_LOG_LEVEL),
+            auto_advance_date: Some(DEFAULT_AUTO_ADVANCE_DATE),
         }
     }
 }
@@ -66,12 +72,14 @@ impl From<ConfigFile> for AppSettings {
         let timezone = file.timezone.unwrap_or(DEFAULT_TIMEZONE);
         let timezone_abbreviation = compute_timezone_abbreviation(timezone);
         let log_level = file.log_level.unwrap_or(DEFAULT_LOG_LEVEL);
+        let auto_advance_date = file.auto_advance_date.unwrap_or(DEFAULT_AUTO_ADVANCE_DATE);
         Self {
             favorite_team,
             full_screen: false,
             timezone,
             timezone_abbreviation,
             log_level,
+            auto_advance_date,
         }
     }
 }
@@ -82,6 +90,7 @@ impl From<&AppSettings> for ConfigFile {
             favorite_team: s.favorite_team.map(|t| t.name.to_string()),
             timezone: Some(s.timezone),
             log_level: Some(s.log_level),
+            auto_advance_date: Some(s.auto_advance_date),
         }
     }
 }

--- a/src/state/app_settings.rs
+++ b/src/state/app_settings.rs
@@ -11,6 +11,7 @@ pub struct AppSettings {
     pub timezone: Tz,
     pub timezone_abbreviation: String,
     pub log_level: LogLevel,
+    pub auto_advance_date: bool,
 }
 
 impl AppSettings {

--- a/src/state/app_state.rs
+++ b/src/state/app_state.rs
@@ -7,6 +7,7 @@ use crate::state::gameday::GamedayState;
 use crate::state::help::HelpState;
 use crate::state::settings_editor::SettingsEditorState;
 use crate::state::stats::StatsState;
+use chrono::NaiveDate;
 
 /// A team must be either Home or Away.
 #[derive(Copy, Clone, Debug, Default, PartialEq)]
@@ -30,4 +31,7 @@ pub struct AppState {
     pub stats: StatsState,
     pub help: HelpState,
     pub settings_editor: SettingsEditorState,
+    /// The system date as of the last rollover check, used to detect a new day. `None` until the
+    /// first check seeds it.
+    pub last_known_today: Option<NaiveDate>,
 }

--- a/src/state/app_state.rs
+++ b/src/state/app_state.rs
@@ -7,7 +7,6 @@ use crate::state::gameday::GamedayState;
 use crate::state::help::HelpState;
 use crate::state::settings_editor::SettingsEditorState;
 use crate::state::stats::StatsState;
-use chrono::NaiveDate;
 
 /// A team must be either Home or Away.
 #[derive(Copy, Clone, Debug, Default, PartialEq)]
@@ -31,7 +30,4 @@ pub struct AppState {
     pub stats: StatsState,
     pub help: HelpState,
     pub settings_editor: SettingsEditorState,
-    /// The system date as of the last rollover check, used to detect a new day. `None` until the
-    /// first check seeds it.
-    pub last_known_today: Option<NaiveDate>,
 }

--- a/src/state/refresher.rs
+++ b/src/state/refresher.rs
@@ -18,6 +18,7 @@ impl PeriodicRefresher {
         let mut schedule_interval = interval(Duration::from_secs(30)); // Schedule every 30s
         let mut standings_interval = interval(Duration::from_secs(1800)); // Standings every 30 minutes
         let mut stats_interval = interval(Duration::from_secs(1800)); // Stats every 30 minutes
+        let mut rollover_interval = interval(Duration::from_secs(60)); // Check for a new day every minute
 
         loop {
             tokio::select! {
@@ -73,6 +74,17 @@ impl PeriodicRefresher {
 
                     if active_tab == MenuItem::Stats {
                         let _ = self.network_requests.send(RefreshableRequest::force(NetworkRequest::Stats { date, stat_type })).await;
+                    }
+                }
+
+                // Roll date-driven tabs over to the new day when the system date changes
+                _ = rollover_interval.tick() => {
+                    let requests = {
+                        let mut app = app.lock().await;
+                        app.advance_dates_on_rollover()
+                    };
+                    for request in requests {
+                        let _ = self.network_requests.send(RefreshableRequest::force(request)).await;
                     }
                 }
             }

--- a/src/state/refresher.rs
+++ b/src/state/refresher.rs
@@ -1,19 +1,25 @@
 use crate::app::{App, MenuItem};
 use crate::state::messages::{NetworkRequest, RefreshableRequest};
+use chrono::NaiveDate;
 use std::time::Duration;
 use tokio::sync::mpsc;
 use tokio::time::interval;
 
 pub struct PeriodicRefresher {
     network_requests: mpsc::Sender<RefreshableRequest>,
+    /// Day seen on the last rollover check. `None` until the first check.
+    prev_today: Option<NaiveDate>,
 }
 
 impl PeriodicRefresher {
     pub fn new(network_requests: mpsc::Sender<RefreshableRequest>) -> Self {
-        Self { network_requests }
+        Self {
+            network_requests,
+            prev_today: None,
+        }
     }
 
-    pub async fn run(self, app: std::sync::Arc<tokio::sync::Mutex<App>>) {
+    pub async fn run(mut self, app: std::sync::Arc<tokio::sync::Mutex<App>>) {
         let mut live_interval = interval(Duration::from_secs(10)); // Live data every 10s
         let mut schedule_interval = interval(Duration::from_secs(30)); // Schedule every 30s
         let mut standings_interval = interval(Duration::from_secs(1800)); // Standings every 30 minutes
@@ -79,10 +85,11 @@ impl PeriodicRefresher {
 
                 // Roll date-driven tabs over to the new day when the system date changes
                 _ = rollover_interval.tick() => {
-                    let requests = {
+                    let (today, requests) = {
                         let mut app = app.lock().await;
-                        app.advance_dates_on_rollover()
+                        app.advance_dates_on_rollover(self.prev_today)
                     };
+                    self.prev_today = Some(today);
                     for request in requests {
                         let _ = self.network_requests.send(RefreshableRequest::force(request)).await;
                     }

--- a/src/state/settings_editor.rs
+++ b/src/state/settings_editor.rs
@@ -20,6 +20,7 @@ pub enum SettingsField {
     FavoriteTeam,
     Timezone,
     LogLevel,
+    AutoAdvanceDate,
 }
 
 /// Transient status shown below the settings form. Cleared on any input that interacts with the
@@ -47,10 +48,11 @@ pub struct PickerState {
 }
 
 impl SettingsField {
-    pub const ALL: [SettingsField; 3] = [
+    pub const ALL: [SettingsField; 4] = [
         SettingsField::FavoriteTeam,
         SettingsField::Timezone,
         SettingsField::LogLevel,
+        SettingsField::AutoAdvanceDate,
     ];
 
     pub fn label(self) -> &'static str {
@@ -58,6 +60,7 @@ impl SettingsField {
             SettingsField::FavoriteTeam => "Team",
             SettingsField::Timezone => "Timezone",
             SettingsField::LogLevel => "Log",
+            SettingsField::AutoAdvanceDate => "Auto-date",
         }
     }
 
@@ -65,15 +68,17 @@ impl SettingsField {
         match self {
             SettingsField::FavoriteTeam => SettingsField::Timezone,
             SettingsField::Timezone => SettingsField::LogLevel,
-            SettingsField::LogLevel => SettingsField::FavoriteTeam,
+            SettingsField::LogLevel => SettingsField::AutoAdvanceDate,
+            SettingsField::AutoAdvanceDate => SettingsField::FavoriteTeam,
         }
     }
 
     pub fn previous(self) -> Self {
         match self {
-            SettingsField::FavoriteTeam => SettingsField::LogLevel,
+            SettingsField::FavoriteTeam => SettingsField::AutoAdvanceDate,
             SettingsField::Timezone => SettingsField::FavoriteTeam,
             SettingsField::LogLevel => SettingsField::Timezone,
+            SettingsField::AutoAdvanceDate => SettingsField::LogLevel,
         }
     }
 
@@ -82,6 +87,7 @@ impl SettingsField {
             SettingsField::FavoriteTeam => TEAM_OPTIONS.len(),
             SettingsField::Timezone => TIMEZONE_OPTIONS.len(),
             SettingsField::LogLevel => LOG_LEVEL_OPTIONS.len(),
+            SettingsField::AutoAdvanceDate => TOGGLE_OPTIONS.len(),
         }
     }
 
@@ -90,6 +96,7 @@ impl SettingsField {
             SettingsField::FavoriteTeam => TEAM_OPTIONS.get(index).map(|o| team_option_label(*o)),
             SettingsField::Timezone => TIMEZONE_OPTIONS.get(index).map(|o| o.picker_label),
             SettingsField::LogLevel => LOG_LEVEL_OPTIONS.get(index).map(|o| o.label),
+            SettingsField::AutoAdvanceDate => TOGGLE_OPTIONS.get(index).map(|o| o.label),
         }
     }
 
@@ -112,6 +119,10 @@ impl SettingsField {
                 .iter()
                 .position(|o| o.value == settings.log_level)
                 .unwrap_or(0),
+            SettingsField::AutoAdvanceDate => TOGGLE_OPTIONS
+                .iter()
+                .position(|o| o.value == settings.auto_advance_date)
+                .unwrap_or(0),
         }
     }
 
@@ -132,6 +143,11 @@ impl SettingsField {
             SettingsField::LogLevel => {
                 if let Some(opt) = LOG_LEVEL_OPTIONS.get(index) {
                     settings.log_level = opt.value;
+                }
+            }
+            SettingsField::AutoAdvanceDate => {
+                if let Some(opt) = TOGGLE_OPTIONS.get(index) {
+                    settings.auto_advance_date = opt.value;
                 }
             }
         }
@@ -234,6 +250,11 @@ pub fn current_value_label(field: SettingsField, settings: &AppSettings) -> Stri
             .find(|o| o.value == settings.log_level)
             .map(|o| o.label.to_string())
             .unwrap_or_else(|| "<unset>".to_string()),
+        SettingsField::AutoAdvanceDate => TOGGLE_OPTIONS
+            .iter()
+            .find(|o| o.value == settings.auto_advance_date)
+            .map(|o| o.label.to_string())
+            .unwrap_or_else(|| "<unset>".to_string()),
     }
 }
 
@@ -277,6 +298,18 @@ pub const LOG_LEVEL_OPTIONS: &[LogLevelOption] = &[
     LogLevelOption {label: "Trace", value: LogLevel::Trace},
 ];
 
+#[derive(Debug, Clone, Copy)]
+pub struct ToggleOption {
+    pub label: &'static str,
+    pub value: bool,
+}
+
+#[rustfmt::skip]
+pub const TOGGLE_OPTIONS: &[ToggleOption] = &[
+    ToggleOption {label: "On", value: true},
+    ToggleOption {label: "Off", value: false},
+];
+
 /// Team picker list: `<none>` sentinel first, then all current MLB teams sorted by name.
 pub static TEAM_OPTIONS: LazyLock<Vec<Option<Team>>> = LazyLock::new(|| {
     let mut v: Vec<Option<Team>> = vec![None];
@@ -304,6 +337,11 @@ pub fn max_value_width(field: SettingsField) -> usize {
             .max()
             .unwrap_or(0),
         SettingsField::LogLevel => LOG_LEVEL_OPTIONS
+            .iter()
+            .map(|o| o.label.chars().count())
+            .max()
+            .unwrap_or(0),
+        SettingsField::AutoAdvanceDate => TOGGLE_OPTIONS
             .iter()
             .map(|o| o.label.chars().count())
             .max()

--- a/src/ui/help/settings_panel.rs
+++ b/src/ui/help/settings_panel.rs
@@ -121,6 +121,7 @@ pub fn render_picker(picker: &PickerState, full_area: Rect, buf: &mut Buffer) {
         SettingsField::FavoriteTeam => " Favorite team ",
         SettingsField::Timezone => " Timezone ",
         SettingsField::LogLevel => " Log level ",
+        SettingsField::AutoAdvanceDate => " Auto-advance date ",
     };
 
     // Size the popup: width wide enough for the longest label + borders + padding, height capped so
@@ -135,7 +136,7 @@ pub fn render_picker(picker: &PickerState, full_area: Rect, buf: &mut Buffer) {
         .min(full_area.width);
     let popup_height = (count as u16 + 2)
         .min(full_area.height.saturating_sub(2))
-        .max(5);
+        .max(4);
 
     let area = centered_rect(full_area, popup_width, popup_height);
 


### PR DESCRIPTION
When the TUI is open overnight this will auto update the date selection to the new day. If you had manually selected a previous date on a tab, that will be kept.

Closes #143 