### PR TITLE
Scoring play selection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Add auto-advance date logic if app is open overnight: [PR 146](https://github.com/mlb-rs/mlbt/pull/146)
+- Add toggle (`!`) to display scoring plays only in Gameday. Thanks @tjweir! [PR 145](https://github.com/mlb-rs/mlbt/pull/145)
 
 ## [0.4.0] - 2026-04-29
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -203,7 +203,7 @@ impl App {
         // only update gameday if the selected game is the same as the game being updated
         // this prevents gameday from showing incorrect data if the user scrolls through games quickly
         if Some(live_data.game_pk) == self.state.schedule.get_selected_game_opt() {
-            self.state.gameday.game.update(live_data, win_probability);
+            self.state.gameday.update(live_data, win_probability);
             // update this after the gameday so the players are correct
             self.state
                 .box_score

--- a/src/components/game/live_game.rs
+++ b/src/components/game/live_game.rs
@@ -132,10 +132,6 @@ impl GameState {
         }
     }
 
-    pub fn count_events(&self) -> usize {
-        self.at_bats.len()
-    }
-
     fn get_current_play_ab_index(live_data: &LiveResponse) -> AtBatIndex {
         live_data
             .live_data

--- a/src/components/help.rs
+++ b/src/components/help.rs
@@ -33,7 +33,7 @@ const SCOREBOARD_DOCS: &[&[&str; 2]; 9] = &[
     &["Scroll boxscore up", "Shift + k/↑"],
     &["Toggle win probability", "w"],
 ];
-const GAMEDAY_DOCS: &[&[&str; 2]; 12] = &[
+const GAMEDAY_DOCS: &[&[&str; 2]; 13] = &[
     &["Gameday", "2"],
     &["Toggle game info", "i"],
     &["Toggle pitches", "p"],
@@ -46,6 +46,7 @@ const GAMEDAY_DOCS: &[&[&str; 2]; 12] = &[
     &["Move up at bat", "k/↑"],
     &["Go to live at bat", "l"],
     &["Go to first at bat", "s"],
+    &["Toggle scoring plays only", "!"],
 ];
 const STATS_DOCS: &[&[&str; 2]; 17] = &[
     &["Stats", "3"],

--- a/src/keys.rs
+++ b/src/keys.rs
@@ -243,11 +243,16 @@ async fn load_team(guard: AppGuard<'_>, network_requests: &mpsc::Sender<Refresha
 }
 
 async fn load_game_data(
-    guard: AppGuard<'_>,
+    mut guard: AppGuard<'_>,
     network_requests: &mpsc::Sender<RefreshableRequest>,
     force: bool,
 ) {
     let game_id = guard.state.schedule.get_selected_game_opt();
+    // No-ops when the game hasn't actually changed, so this is safe on every call site. Clearing
+    // stale data from the previous game up front avoids it lingering on screen while the new
+    // game's data loads.
+    guard.state.gameday.reset(game_id);
+    guard.state.box_score.reset(game_id);
     drop(guard);
 
     if let Some(game_id) = game_id {

--- a/src/state/gameday.rs
+++ b/src/state/gameday.rs
@@ -6,12 +6,13 @@ pub struct GamedayState {
     pub panels: GamedayPanels,
     pub game: GameState,
     pub scoring_plays_only: bool,
-    selected_at_bat: Option<usize>,
+    /// The at bat index (map key) that is currently selected, or `None` when live.
+    selected_at_bat: Option<u8>,
 }
 
 impl GamedayState {
     pub fn selected_at_bat(&self) -> Option<u8> {
-        self.selected_at_bat.map(|i| i as u8)
+        self.selected_at_bat
     }
 
     pub fn current_game_id(&self) -> u64 {
@@ -35,31 +36,51 @@ impl GamedayState {
         }
     }
 
-    pub fn next_at_bat(&mut self) {
-        let count = self.game.count_events();
-        if count == 0 {
-            return;
+    /// The at bat indexes that can be navigated to, in game order. When `scoring_plays_only` is
+    /// enabled this is restricted to scoring plays, so scrolling skips everything else.
+    fn navigable_at_bats(&self) -> Vec<u8> {
+        self.game
+            .at_bats
+            .values()
+            .filter(|at_bat| !self.scoring_plays_only || at_bat.play_result.is_scoring_play)
+            .map(|at_bat| at_bat.index)
+            .collect()
+    }
+
+    /// The navigable at bat indexes and the position of the current selection within them. Returns
+    /// `None` when there is nothing to navigate. The inner `None` means nothing is selected yet.
+    fn navigable_selection(&self) -> Option<(Vec<u8>, Option<usize>)> {
+        let indexes = self.navigable_at_bats();
+        if indexes.is_empty() {
+            return None;
         }
-        let i = match self.selected_at_bat {
-            Some(i) if i >= count - 1 => 0,
-            Some(i) => i + 1,
+        let pos = self
+            .selected_at_bat
+            .and_then(|selected| indexes.iter().position(|&i| i == selected));
+        Some((indexes, pos))
+    }
+
+    pub fn next_at_bat(&mut self) {
+        let Some((indexes, pos)) = self.navigable_selection() else {
+            return;
+        };
+        let next = match pos {
+            Some(p) if p >= indexes.len() - 1 => 0,
+            Some(p) => p + 1,
             None => 0,
         };
-
-        self.selected_at_bat = Some(i);
+        self.selected_at_bat = Some(indexes[next]);
     }
 
     pub fn previous_at_bat(&mut self) {
-        let count = self.game.count_events();
-        if count == 0 {
+        let Some((indexes, pos)) = self.navigable_selection() else {
             return;
-        }
-        let i = match self.selected_at_bat {
-            None => count - 1,
-            Some(0) => count - 1,
-            Some(i) => i - 1,
         };
-        self.selected_at_bat = Some(i);
+        let prev = match pos {
+            None | Some(0) => indexes.len() - 1,
+            Some(p) => p - 1,
+        };
+        self.selected_at_bat = Some(indexes[prev]);
     }
 
     /// Go to "live" at bat by deselecting the current at bat.
@@ -69,7 +90,7 @@ impl GamedayState {
 
     /// Go to the start of the game.
     pub fn start(&mut self) {
-        self.selected_at_bat = Some(0);
+        self.selected_at_bat = self.navigable_at_bats().first().copied();
     }
 
     pub fn toggle_info(&mut self) {
@@ -90,6 +111,24 @@ impl GamedayState {
 
     pub fn toggle_scoring_plays_only(&mut self) {
         self.scoring_plays_only = !self.scoring_plays_only;
+        if self.scoring_plays_only {
+            self.snap_to_scoring_play();
+        }
+    }
+
+    /// When enabling scoring plays only, move the selection onto a scoring play so the cursor is
+    /// visible. Keeps a selection that is already a scoring play, snaps a non-scoring selection to
+    /// the closest scoring play, and selects the most recent scoring play when live.
+    fn snap_to_scoring_play(&mut self) {
+        let scoring = self.navigable_at_bats();
+        self.selected_at_bat = match self.selected_at_bat {
+            Some(selected) if scoring.contains(&selected) => Some(selected),
+            Some(selected) => scoring
+                .iter()
+                .min_by_key(|&&i| i.abs_diff(selected))
+                .copied(),
+            None => scoring.last().copied(),
+        };
     }
 }
 
@@ -117,5 +156,107 @@ impl Default for GamedayPanels {
             boxscore: false,
             win_probability: true,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::components::game::at_bat::AtBat;
+
+    /// Build a state whose at bats have the given indexes, marking the listed indexes as scoring
+    /// plays.
+    fn state_with(indexes: &[u8], scoring: &[u8]) -> GamedayState {
+        let mut state = GamedayState::default();
+        for &index in indexes {
+            let mut at_bat = AtBat {
+                index,
+                ..Default::default()
+            };
+            at_bat.play_result.is_scoring_play = scoring.contains(&index);
+            state.game.at_bats.insert(index, at_bat);
+        }
+        state
+    }
+
+    #[test]
+    fn navigation_walks_every_play_normally() {
+        let mut state = state_with(&[0, 1, 2], &[1]);
+
+        state.next_at_bat();
+        assert_eq!(state.selected_at_bat(), Some(0));
+        state.next_at_bat();
+        assert_eq!(state.selected_at_bat(), Some(1));
+        state.previous_at_bat();
+        assert_eq!(state.selected_at_bat(), Some(0));
+        // wraps to the last at bat
+        state.previous_at_bat();
+        assert_eq!(state.selected_at_bat(), Some(2));
+        state.next_at_bat();
+        assert_eq!(state.selected_at_bat(), Some(0));
+    }
+
+    #[test]
+    fn navigation_skips_non_scoring_plays_when_filtered() {
+        let mut state = state_with(&[0, 1, 2, 3, 4], &[1, 3]);
+        state.scoring_plays_only = true;
+
+        // only scoring plays are reachable, in order
+        state.next_at_bat();
+        assert_eq!(state.selected_at_bat(), Some(1));
+        state.next_at_bat();
+        assert_eq!(state.selected_at_bat(), Some(3));
+        // wraps back to the first scoring play
+        state.next_at_bat();
+        assert_eq!(state.selected_at_bat(), Some(1));
+        state.previous_at_bat();
+        assert_eq!(state.selected_at_bat(), Some(3));
+    }
+
+    #[test]
+    fn start_respects_scoring_filter() {
+        let mut state = state_with(&[0, 1, 2, 3], &[2]);
+        state.start();
+        assert_eq!(state.selected_at_bat(), Some(0));
+
+        state.scoring_plays_only = true;
+        state.start();
+        assert_eq!(state.selected_at_bat(), Some(2));
+    }
+
+    #[test]
+    fn toggle_snaps_selection_to_nearest_scoring_play() {
+        let mut state = state_with(&[0, 1, 2, 3, 4], &[1, 4]);
+
+        // selecting a non scoring play then filtering snaps to the closest scoring play
+        state.selected_at_bat = Some(3);
+        state.toggle_scoring_plays_only();
+        assert_eq!(state.selected_at_bat(), Some(4));
+
+        // an already scoring selection is left untouched
+        state.toggle_scoring_plays_only(); // off
+        state.selected_at_bat = Some(1);
+        state.toggle_scoring_plays_only(); // on
+        assert_eq!(state.selected_at_bat(), Some(1));
+
+        // toggling on while live selects the most recent scoring play
+        state.toggle_scoring_plays_only(); // off
+        state.live();
+        state.toggle_scoring_plays_only(); // on
+        assert_eq!(state.selected_at_bat(), Some(4));
+    }
+
+    #[test]
+    fn navigation_is_a_noop_without_navigable_plays() {
+        // no at bats at all
+        let mut empty = GamedayState::default();
+        empty.next_at_bat();
+        assert_eq!(empty.selected_at_bat(), None);
+
+        // at bats exist but none score, with the filter on
+        let mut none_score = state_with(&[0, 1], &[]);
+        none_score.scoring_plays_only = true;
+        none_score.next_at_bat();
+        assert_eq!(none_score.selected_at_bat(), None);
     }
 }

--- a/src/state/gameday.rs
+++ b/src/state/gameday.rs
@@ -1,5 +1,7 @@
 use crate::components::game::live_game::GameState;
+use mlbt_api::live::LiveResponse;
 use mlbt_api::schedule::AbstractGameState;
+use mlbt_api::win_probability::WinProbabilityResponse;
 
 #[derive(Default)]
 pub struct GamedayState {
@@ -8,6 +10,9 @@ pub struct GamedayState {
     pub scoring_plays_only: bool,
     /// The at bat index (map key) that is currently selected, or `None` when live.
     selected_at_bat: Option<u8>,
+    /// Snap to a scoring play when the next update arrives. Set when switching games with the
+    /// scoring play filter on, since the new game's at bats load asynchronously.
+    snap_pending: bool,
 }
 
 impl GamedayState {
@@ -30,9 +35,33 @@ impl GamedayState {
         let new_id = game_id.unwrap_or(0);
 
         if self.game.game_id != new_id {
-            self.selected_at_bat = None;
+            self.on_game_changing();
             self.game.reset();
             self.game.game_id = new_id;
+        }
+    }
+
+    /// Update with latest data from the API, snapping to a scoring play if a game switch left one
+    /// pending. Detects a game switch here too since `GameData` responses from directly navigating
+    /// games (rather than a schedule refresh) arrive without a prior call to `reset`.
+    pub fn update(&mut self, live_data: &LiveResponse, win_probability: &WinProbabilityResponse) {
+        if self.game.game_id != live_data.game_pk {
+            self.on_game_changing();
+        }
+        self.game.update(live_data, win_probability);
+        self.snap_if_pending();
+    }
+
+    /// Clear the selection and, if the scoring play filter is on, mark a snap as pending once the
+    /// new game's at bats load.
+    fn on_game_changing(&mut self) {
+        self.selected_at_bat = None;
+        self.snap_pending = self.scoring_plays_only;
+    }
+
+    fn snap_if_pending(&mut self) {
+        if std::mem::take(&mut self.snap_pending) && self.scoring_plays_only {
+            self.snap_to_scoring_play();
         }
     }
 
@@ -83,14 +112,21 @@ impl GamedayState {
         self.selected_at_bat = Some(indexes[prev]);
     }
 
-    /// Go to "live" at bat by deselecting the current at bat.
+    /// Go to "live" at bat by deselecting the current at bat. When the scoring play filter is
+    /// enabled, "live" means the most recent scoring play instead, matching what enabling the
+    /// filter while live already selects.
     pub fn live(&mut self) {
         self.selected_at_bat = None;
+        if self.scoring_plays_only {
+            self.snap_to_scoring_play();
+        }
     }
 
     /// Go to the start of the game.
     pub fn start(&mut self) {
-        self.selected_at_bat = self.navigable_at_bats().first().copied();
+        if let Some(first) = self.navigable_at_bats().first() {
+            self.selected_at_bat = Some(*first);
+        }
     }
 
     pub fn toggle_info(&mut self) {
@@ -116,13 +152,16 @@ impl GamedayState {
         }
     }
 
-    /// When enabling scoring plays only, move the selection onto a scoring play so the cursor is
-    /// visible. Keeps a selection that is already a scoring play, snaps a non-scoring selection to
-    /// the closest scoring play, and selects the most recent scoring play when live.
+    /// Move the selection onto a scoring play so the cursor is visible while the filter is
+    /// enabled. Snaps to the closest scoring play, which keeps a selection that already scores,
+    /// and selects the most recent scoring play when live. A game with no scoring plays leaves the
+    /// selection untouched.
     fn snap_to_scoring_play(&mut self) {
         let scoring = self.navigable_at_bats();
+        if scoring.is_empty() {
+            return;
+        }
         self.selected_at_bat = match self.selected_at_bat {
-            Some(selected) if scoring.contains(&selected) => Some(selected),
             Some(selected) => scoring
                 .iter()
                 .min_by_key(|&&i| i.abs_diff(selected))
@@ -163,11 +202,18 @@ impl Default for GamedayPanels {
 mod tests {
     use super::*;
     use crate::components::game::at_bat::AtBat;
+    use mlbt_api::live::LiveData;
+    use mlbt_api::plays::{About, Play, Plays};
 
     /// Build a state whose at bats have the given indexes, marking the listed indexes as scoring
     /// plays.
     fn state_with(indexes: &[u8], scoring: &[u8]) -> GamedayState {
         let mut state = GamedayState::default();
+        insert_at_bats(&mut state, indexes, scoring);
+        state
+    }
+
+    fn insert_at_bats(state: &mut GamedayState, indexes: &[u8], scoring: &[u8]) {
         for &index in indexes {
             let mut at_bat = AtBat {
                 index,
@@ -176,7 +222,6 @@ mod tests {
             at_bat.play_result.is_scoring_play = scoring.contains(&index);
             state.game.at_bats.insert(index, at_bat);
         }
-        state
     }
 
     #[test]
@@ -225,6 +270,29 @@ mod tests {
     }
 
     #[test]
+    fn live_snaps_to_latest_scoring_play_when_filtered() {
+        // this is what the `1` (Scoreboard) key calls on the way out of Gameday. Without the
+        // filter check, repeatedly switching to Scoreboard and back to the same, already-loaded
+        // game (no game id change, so nothing re-snaps on return) would strand the selection on
+        // live instead of a scoring play.
+        let mut state = state_with(&[0, 1, 2, 3, 4], &[1, 3]);
+        state.scoring_plays_only = true;
+        state.selected_at_bat = Some(1);
+
+        state.live();
+        assert_eq!(state.selected_at_bat(), Some(3));
+
+        // idempotent across repeated round trips
+        state.live();
+        assert_eq!(state.selected_at_bat(), Some(3));
+
+        // without the filter, live still means truly live
+        state.scoring_plays_only = false;
+        state.live();
+        assert_eq!(state.selected_at_bat(), None);
+    }
+
+    #[test]
     fn toggle_snaps_selection_to_nearest_scoring_play() {
         let mut state = state_with(&[0, 1, 2, 3, 4], &[1, 4]);
 
@@ -244,6 +312,99 @@ mod tests {
         state.live();
         state.toggle_scoring_plays_only(); // on
         assert_eq!(state.selected_at_bat(), Some(4));
+    }
+
+    /// Build a `LiveResponse` for the given game with at bats at the given indexes, marking the
+    /// listed indexes as scoring plays. Mirrors a real `GameDataLoaded` network response.
+    fn live_response(game_pk: u64, indexes: &[u8], scoring: &[u8]) -> LiveResponse {
+        let all_plays = indexes
+            .iter()
+            .map(|&index| Play {
+                about: About {
+                    at_bat_index: index,
+                    is_scoring_play: Some(scoring.contains(&index)),
+                    ..Default::default()
+                },
+                ..Default::default()
+            })
+            .collect();
+        LiveResponse {
+            game_pk,
+            live_data: LiveData {
+                plays: Plays {
+                    all_plays: Some(all_plays),
+                    ..Default::default()
+                },
+                ..Default::default()
+            },
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn switching_games_via_direct_navigation_snaps_to_scoring_play() {
+        // this is the path taken when the user selects a different game with j/k on the
+        // Scoreboard tab: `GameData` responses arrive via `update` directly, with no prior call to
+        // `reset` (that only happens on a schedule refresh).
+        let mut state = state_with(&[0, 1, 2], &[1]);
+        state.scoring_plays_only = true;
+        state.selected_at_bat = Some(1);
+
+        let win_probability = WinProbabilityResponse::default();
+        let response = live_response(6, &[0, 1, 2, 3], &[1, 3]);
+        state.update(&response, &win_probability);
+
+        assert_eq!(state.game.game_id, 6);
+        assert_eq!(state.selected_at_bat(), Some(3));
+
+        // a later update for the same game doesn't re-snap and drag the selection along
+        state.previous_at_bat();
+        assert_eq!(state.selected_at_bat(), Some(1));
+        state.update(&response, &win_probability);
+        assert_eq!(state.selected_at_bat(), Some(1));
+    }
+
+    #[test]
+    fn switching_games_without_filter_just_clears_the_selection() {
+        let mut state = state_with(&[0, 1, 2], &[1]);
+        state.selected_at_bat = Some(1);
+
+        let win_probability = WinProbabilityResponse::default();
+        let response = live_response(6, &[0, 1, 2, 3], &[1, 3]);
+        state.update(&response, &win_probability);
+
+        assert_eq!(state.selected_at_bat(), None);
+    }
+
+    #[test]
+    fn switching_games_via_schedule_refresh_snaps_to_scoring_play() {
+        // this is the path taken on a schedule poll: `reset` runs first (before at bats have
+        // loaded), then the `GameData` response arrives separately via `update`.
+        let mut state = state_with(&[0, 1, 2], &[1]);
+        state.scoring_plays_only = true;
+        state.selected_at_bat = Some(1);
+
+        state.reset(Some(6));
+        assert_eq!(state.selected_at_bat(), None);
+
+        let win_probability = WinProbabilityResponse::default();
+        let response = live_response(6, &[0, 1, 2, 3], &[1, 3]);
+        state.update(&response, &win_probability);
+        assert_eq!(state.selected_at_bat(), Some(3));
+    }
+
+    #[test]
+    fn filter_keeps_selection_without_scoring_plays() {
+        let mut state = state_with(&[0, 1, 2], &[]);
+        state.selected_at_bat = Some(1);
+
+        // toggling the filter on has no scoring play to snap to
+        state.toggle_scoring_plays_only();
+        assert_eq!(state.selected_at_bat(), Some(1));
+
+        // going to the start has nowhere to go either
+        state.start();
+        assert_eq!(state.selected_at_bat(), Some(1));
     }
 
     #[test]

--- a/src/ui/gameday/gameday_widget.rs
+++ b/src/ui/gameday/gameday_widget.rs
@@ -10,7 +10,8 @@ use crate::ui::gameday::plays::InningPlaysWidget;
 use crate::ui::gameday::win_probability::WinProbabilityWidget;
 use crate::ui::layout::LayoutAreas;
 use crate::ui::linescore::LineScoreWidget;
-use tui::prelude::{Buffer, Rect, Widget};
+use crate::ui::styling::selected_style;
+use tui::prelude::{Buffer, Rect, Span, Widget};
 
 pub struct GamedayWidget<'a> {
     pub state: &'a GamedayState,
@@ -61,7 +62,11 @@ impl Widget for GamedayWidget<'_> {
         }
         if self.state.panels.info {
             let p = panels.pop().unwrap();
-            Self::draw_border(p, buf);
+            if self.state.scoring_plays_only {
+                Self::draw_border_with_title(p, buf, " Scoring Plays ");
+            } else {
+                Self::draw_border(p, buf);
+            };
             let chunks = LayoutAreas::for_info(p, self.state.panels.win_probability);
 
             let innings_widget = InningPlaysWidget {
@@ -86,6 +91,11 @@ impl Widget for GamedayWidget<'_> {
 impl GamedayWidget<'_> {
     fn draw_border(area: Rect, buf: &mut Buffer) {
         let block = draw::default_border();
+        Widget::render(block, area, buf);
+    }
+
+    fn draw_border_with_title(area: Rect, buf: &mut Buffer, title: &str) {
+        let block = draw::default_border().title(Span::styled(title, selected_style()));
         Widget::render(block, area, buf);
     }
 }


### PR DESCRIPTION
- when the scoring plays toggle is on, the at bat selection now only scrolls through the scoring plays instead of all at bats (including the win probability)
- also added a "Scoring Plays" title when the toggle is on

<img width="2050" height="1400" alt="scoring-plays" src="https://github.com/user-attachments/assets/d30cf06d-4117-4c1a-9e79-5da2f9be309c" />
