### PR TITLE
Enable scrolling for gameday plays

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add auto-advance date logic if app is open overnight: [PR 146](https://github.com/mlb-rs/mlbt/pull/146)
 - Add toggle (`!`) to display scoring plays only in Gameday. Thanks @tjweir! [PR 145](https://github.com/mlb-rs/mlbt/pull/145)
 
+### Fixed
+
+- Scrolling plays in the Gameday view now works correctly: [PR 148](https://github.com/mlb-rs/mlbt/pull/148)
+
 ## [0.4.0] - 2026-04-29
 
 ### Added

--- a/src/draw.rs
+++ b/src/draw.rs
@@ -227,7 +227,7 @@ fn draw_gameday(f: &mut Frame, rect: Rect, app: &mut App) {
     f.render_widget(
         GamedayWidget {
             active: app.state.box_score.active_team,
-            state: &app.state.gameday,
+            state: &mut app.state.gameday,
             boxscore_state: &mut app.state.box_score,
         },
         rect,

--- a/src/state/gameday.rs
+++ b/src/state/gameday.rs
@@ -2,6 +2,7 @@ use crate::components::game::live_game::GameState;
 use mlbt_api::live::LiveResponse;
 use mlbt_api::schedule::AbstractGameState;
 use mlbt_api::win_probability::WinProbabilityResponse;
+use tui::widgets::ScrollbarState;
 
 #[derive(Default)]
 pub struct GamedayState {
@@ -13,6 +14,8 @@ pub struct GamedayState {
     /// Snap to a scoring play when the next update arrives. Set when switching games with the
     /// scoring play filter on, since the new game's at bats load asynchronously.
     snap_pending: bool,
+    pub plays_scroll_offset: u16,
+    pub plays_scroll_state: ScrollbarState,
 }
 
 impl GamedayState {

--- a/src/ui/gameday/gameday_widget.rs
+++ b/src/ui/gameday/gameday_widget.rs
@@ -14,7 +14,7 @@ use crate::ui::styling::selected_style;
 use tui::prelude::{Buffer, Rect, Span, Widget};
 
 pub struct GamedayWidget<'a> {
-    pub state: &'a GamedayState,
+    pub state: &'a mut GamedayState,
     pub boxscore_state: &'a mut BoxscoreState,
     pub active: HomeOrAway,
 }
@@ -73,6 +73,8 @@ impl Widget for GamedayWidget<'_> {
                 game: &self.state.game,
                 selected_at_bat: self.state.selected_at_bat(),
                 scoring_only: self.state.scoring_plays_only,
+                scroll_offset: &mut self.state.plays_scroll_offset,
+                scroll_state: &mut self.state.plays_scroll_state,
             };
             Widget::render(innings_widget, chunks[0], buf);
 

--- a/src/ui/gameday/plays.rs
+++ b/src/ui/gameday/plays.rs
@@ -1,9 +1,10 @@
 use crate::components::game::live_game::GameState;
 use crate::components::game::plays::PlayResult;
+use crate::ui::scroll::render_scrollbar;
 use crate::ui::styling::TEXT_COLOR;
 use std::vec;
 use tui::prelude::*;
-use tui::widgets::{Paragraph, Wrap};
+use tui::widgets::{Paragraph, ScrollbarState, Wrap};
 
 // These colors match the green and blue used in the pitch data from the API.
 // The green is used for pitches called as balls.
@@ -19,32 +20,91 @@ pub struct InningPlaysWidget<'a> {
     pub game: &'a GameState,
     pub selected_at_bat: Option<u8>,
     pub scoring_only: bool,
+    pub scroll_offset: &'a mut u16,
+    pub scroll_state: &'a mut ScrollbarState,
 }
 
 impl Widget for InningPlaysWidget<'_> {
     fn render(self, area: Rect, buf: &mut Buffer) {
-        // TODO this doesn't scroll properly. needs to be a list for that
-        let inning_plays = format_plays(self.game, self.selected_at_bat, self.scoring_only);
-        let paragraph = Paragraph::new(inning_plays).wrap(Wrap { trim: false });
+        let (lines, selected_idx) =
+            format_plays(self.game, self.selected_at_bat, self.scoring_only);
 
-        Widget::render(paragraph, area, buf);
+        let content_height = measure(&lines, area.width);
+        let paragraph = Paragraph::new(lines.clone()).wrap(Wrap { trim: false });
+
+        // Everything fits, so render without scrolling.
+        if content_height <= area.height {
+            *self.scroll_offset = 0;
+            *self.scroll_state = ScrollbarState::default();
+            Widget::render(paragraph, area, buf);
+            return;
+        }
+
+        // Follow the selection so it stays on screen. Lines wrap, so measure its start row and height.
+        let selected = selected_idx.map(|idx| {
+            let start = measure(&lines[..idx], area.width);
+            let height = measure(&lines[idx..=idx], area.width);
+            (start, height)
+        });
+        let offset = follow_selection(*self.scroll_offset, selected, area.height, content_height);
+
+        *self.scroll_offset = offset;
+        *self.scroll_state = ScrollbarState::default()
+            .content_length(content_height as usize)
+            .position(offset as usize);
+
+        Widget::render(paragraph.scroll((offset, 0)), area, buf);
+        render_scrollbar(area, self.scroll_state, buf);
     }
 }
 
-/// Format the plays for the current inning as TUI Lines.
+/// Nudge the offset to keep the selection in view, moving only when it would fall off screen.
+/// `content` and `viewport` are wrapped row counts. With no selection, stay at the top.
+fn follow_selection(
+    current: u16,
+    selected: Option<(u16, u16)>,
+    viewport: u16,
+    content: u16,
+) -> u16 {
+    /// Rows of context kept around the selection so its inning header (the row above) stays visible.
+    const SCROLL_MARGIN: u16 = 1;
+
+    let max = content.saturating_sub(viewport);
+    let Some((start, height)) = selected else {
+        return 0;
+    };
+    let mut offset = current.min(max);
+    if start < offset + SCROLL_MARGIN {
+        offset = start.saturating_sub(SCROLL_MARGIN);
+    } else if start + height + SCROLL_MARGIN > offset + viewport {
+        offset = (start + height + SCROLL_MARGIN).saturating_sub(viewport);
+    }
+    offset.min(max)
+}
+
+/// Measure the wrapped height, in rows, that `lines` occupy at the given width.
+fn measure(lines: &[Line<'_>], width: u16) -> u16 {
+    Paragraph::new(lines.to_vec())
+        .wrap(Wrap { trim: false })
+        .line_count(width) as u16
+}
+
+/// Format the plays for the current inning as TUI Lines, returning the index of the line for the
+/// selected at bat when one is shown.
 fn format_plays(
     game: &GameState,
     selected_at_bat: Option<u8>,
     scoring_only: bool,
-) -> Vec<Line<'_>> {
+) -> (Vec<Line<'_>>, Option<usize>) {
     let (at_bat, _is_current) = game.get_at_bat_by_index_or_current(selected_at_bat);
     let inning = at_bat.inning;
 
     if inning == 0 {
-        return vec![];
+        return (vec![], None);
     }
 
     let mut lines = Vec::new();
+    let mut selected_idx = None;
 
     // Track last inning and top/bottom half
     let mut last_inning: Option<(bool, u8)> = None;
@@ -76,11 +136,14 @@ fn format_plays(
             game.home_team.abbreviation,
             game.away_team.abbreviation,
         ) {
+            if selected_at_bat == Some(play.play_result.at_bat_index) {
+                selected_idx = Some(lines.len());
+            }
             lines.push(line);
         }
     }
 
-    lines
+    (lines, selected_idx)
 }
 
 fn build_line<'a>(
@@ -185,5 +248,32 @@ fn format_outs(play: &PlayResult) -> Span<'_> {
         Span::raw(format!(" {} {}", &play.count.outs, out)).bold()
     } else {
         Span::raw("")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn follow_selection_keeps_the_cursor_in_view() {
+        // viewport of 10 rows over 30 rows of content, so the offset can range 0..=20
+        let viewport = 10;
+        let content = 30;
+
+        // nothing selected parks the view at the top where the newest plays render
+        assert_eq!(follow_selection(15, None, viewport, content), 0);
+
+        // an already visible selection leaves the offset untouched
+        assert_eq!(follow_selection(5, Some((8, 1)), viewport, content), 5);
+
+        // a selection above the viewport scrolls up, keeping one row of header context above it
+        assert_eq!(follow_selection(12, Some((4, 1)), viewport, content), 3);
+
+        // a selection below the viewport scrolls down, leaving one row of context below it
+        assert_eq!(follow_selection(0, Some((14, 2)), viewport, content), 7);
+
+        // the offset never exceeds the max scroll, even chasing the last line
+        assert_eq!(follow_selection(0, Some((29, 1)), viewport, content), 20);
     }
 }

--- a/src/ui/layout.rs
+++ b/src/ui/layout.rs
@@ -81,6 +81,7 @@ impl LayoutAreas {
         Layout::vertical(constraints)
             .horizontal_margin(2)
             .vertical_margin(1)
+            .spacing(1) // one row of padding between the plays and the win probability chart
             .split(rect)
             .to_vec()
     }


### PR DESCRIPTION
Scrolling now works for game day plays instead of getting cut off. This is helpful when scoring-plays-only is on, and all plays if the inning is long.